### PR TITLE
[이규호] SideMenu 컴포넌트 UI 완성

### DIFF
--- a/components/common/SideMenu/AddDashBoard.tsx
+++ b/components/common/SideMenu/AddDashBoard.tsx
@@ -1,0 +1,33 @@
+import styled from "styled-components";
+import AddBoxIcon from "@/public/icon/add_box.svg";
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import {FONT_12B} from '@/styles/FontStyles';
+import { GRAY } from '@/styles/ColorStyles';
+
+function AddDashBoard() {
+  return (
+    <Container>
+      <Words>Dash Boards</Words>
+      <AddBoxIcon />
+    </Container>
+  );
+}
+
+export default AddDashBoard;
+
+const Container = styled.div`
+  width: 100%;
+  margin-top: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const Words = styled.span`
+  color: ${GRAY[50]};
+  ${FONT_12B};
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: none;
+  }
+`;

--- a/components/common/SideMenu/DashBoard.tsx
+++ b/components/common/SideMenu/DashBoard.tsx
@@ -1,0 +1,69 @@
+import styled from "styled-components";
+import Crown from "@/public/icon/crown.svg";
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import {FONT_18, FONT_16} from '@/styles/FontStyles';
+import { GRAY } from '@/styles/ColorStyles';
+
+interface DashBoardProps {
+  color: string;
+  title: string;
+  createdByMe?: boolean;
+  key: number;
+}
+
+function DashBoard({ color, title, createdByMe }: DashBoardProps) {
+  return (
+    <Container>
+      <Color color={color} />
+      <DashBoardTitle>{title}</DashBoardTitle>
+      {createdByMe && <StyledCrown />}
+    </Container>
+  );
+}
+
+export default DashBoard;
+
+const Container = styled.div`
+  width: 276px;
+  height: 45px;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  flex-shrink: 0;
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    width: 134px;
+    height: 43px;
+  }
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    width: 40px;
+    height: 40px;
+    justify-content: center;
+  }
+`;
+
+const Color = styled.div<{ color: string }>`
+  width: 8px;
+  height: 8px;
+  margin-right: 16px;
+  background-color: ${(props) => props.color};
+  border-radius: 100%;
+`;
+
+const DashBoardTitle = styled.div`
+  margin-right: 6px;
+  color: ${GRAY[50]};
+  ${FONT_18};
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-right: 4px;
+    ${FONT_16};
+  }
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: none;
+  }
+`;
+
+const StyledCrown = styled(Crown)`
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: none;
+  }
+`;

--- a/components/common/SideMenu/LogoLink.tsx
+++ b/components/common/SideMenu/LogoLink.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import styled from "styled-components";
+import LargeLogo from '@/public/images/logo_large.svg';
+import SmallLogo from '@/public/images/logo_small.svg';
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+
+
+function LogoLink() {
+  return (
+    <Link href="/">
+      <LogoWrapper>
+        <LargeLogoImg />
+        <SmallLogoImg />
+      </LogoWrapper>
+    </Link>
+  );
+}
+
+export default LogoLink;
+
+const LogoWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const LargeLogoImg = styled(LargeLogo)`
+  display: block;
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: none;
+  }
+`;
+
+const SmallLogoImg = styled(SmallLogo)`
+  display: none;
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: block;
+  }
+`;

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import mock from "./mock";
+import AddDashBoard from "./AddDashBoard";
+import DashBoard from "./DashBoard";
+import LogoLink from "./LogoLink";
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+
+function SideMenu() {
+  const data = mock.dashboards;
+
+  return (
+    <Wrapper>
+      <LogoLink />
+      <AddDashBoard />
+      <DashboardList>
+        {data.map((dashboard, key) => (
+          <DashBoard key={dashboard.id} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} />
+        ))}
+      </DashboardList>
+    </Wrapper>
+  );
+}
+
+export default SideMenu;
+
+const Wrapper = styled.div`
+  width: 300px;
+  height: 1550px;
+  padding: 20px 24px;
+  box-shadow: rgba(0, 0, 0, 0.15) 1.95px 0 0 0;
+  display: flex;
+  flex-direction: column;
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    width: 160px;
+    height: 1666px;
+  }
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    width: 67px;
+    height: 1859px;
+  }
+`;
+
+const DashboardList = styled.div`
+  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-top: 18px;
+  }
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-top: 22px;
+  }
+`;

--- a/components/common/SideMenu/mock.ts
+++ b/components/common/SideMenu/mock.ts
@@ -1,0 +1,53 @@
+const dashboardData = {
+  cursorId: 0,
+  totalCount: 5,
+  dashboards: [
+    {
+      id: 0,
+      title: "송규경",
+      color: "#7AC555",
+      createdAt: "2023-12-19T05:47:11.421Z",
+      updatedAt: "2023-12-19T05:47:11.421Z",
+      createdByMe: true,
+      userId: 0,
+    },
+    {
+      id: 1,
+      title: "안희원",
+      color: "#FFA500",
+      createdAt: "2023-12-19T05:47:11.421Z",
+      updatedAt: "2023-12-19T05:47:11.421Z",
+      createdByMe: true,
+      userId: 1,
+    },
+    {
+      id: 2,
+      title: "안유진",
+      color: "#76A5EA",
+      createdAt: "2023-12-19T05:47:11.421Z",
+      updatedAt: "2023-12-19T05:47:11.421Z",
+      createdByMe: true,
+      userId: 2,
+    },
+    {
+      id: 3,
+      title: "이규호",
+      color: "#E876EA",
+      createdAt: "2023-12-19T05:47:11.421Z",
+      updatedAt: "2023-12-19T05:47:11.421Z",
+      createdByMe: false,
+      userId: 3,
+    },
+    {
+      id: 4,
+      title: "이태희",
+      color: "#760DDE",
+      createdAt: "2023-12-19T05:47:11.421Z",
+      updatedAt: "2023-12-19T05:47:11.421Z",
+      createdByMe: true,
+      userId: 4,
+    },
+  ],
+};
+
+export default dashboardData;

--- a/styles/FontStyles.ts
+++ b/styles/FontStyles.ts
@@ -65,6 +65,11 @@ export const FONT_14 = css`
   font-weight: 500;
   line-height: 150%;
 `;
+export const FONT_12B = css`
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 150%;
+`;
 export const FONT_12 = css`
   font-size: 1.2rem;
   font-weight: 500;


### PR DESCRIPTION
## 수정 내용

- SideMenu 컴포넌트 UI 완성했습니다

## (선택) 스크린샷
<img width="277" alt="20" src="https://github.com/like-tenten/tenten/assets/101032270/90c56ca8-ecac-421a-ae25-3a9952625af4">
<img width="185" alt="21" src="https://github.com/like-tenten/tenten/assets/101032270/20a15521-c465-44a6-8e0e-ba10ae7aa3c1">
<img width="107" alt="22" src="https://github.com/like-tenten/tenten/assets/101032270/7e6a2573-1513-4186-a34d-a0e7911dc819">


## 기타
