### PR TITLE
[안희원] /myboard 페이지 UI 완성

### DIFF
--- a/components/common/Header/MainHeader.tsx
+++ b/components/common/Header/MainHeader.tsx
@@ -14,7 +14,7 @@ function MainHeader() {
         <StyledTaskify />
       </Left>
       <Right>
-        <StyledLink href="/signin">로그인</StyledLink>
+        <StyledLink href="/login">로그인</StyledLink>
         <StyledLink href="/signup">회원가입</StyledLink>
       </Right>
     </Wrapper>

--- a/components/common/Header/Second.tsx
+++ b/components/common/Header/Second.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { ReactNode } from 'react';
-import { BLACK, GRAY } from '@/styles/ColorStyles';
+import { BLACK, GRAY, WHITE } from '@/styles/ColorStyles';
 import { FONT_14, FONT_16, FONT_20_B } from '@/styles/FontStyles';
 import Button from '@/components/common/Button';
 import Profile from '@/components/common/Profile/Profile';
@@ -11,6 +11,7 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import Setting from '@/public/icon/settings.svg';
 import Invite from '@/public/icon/add_box.svg';
 import Crown from '@/public/icon/crown.svg';
+import { Z_INDEX } from '@/styles/ZIndexStyles';
 
 interface Props {
   page: 'myboard' | 'others';
@@ -71,10 +72,16 @@ const Body = styled.div`
   height: 70px;
   padding-left: 300px;
 
+  position: fixed;
+  top: 0;
+  z-index: ${Z_INDEX.secondHeader_Body};
+
   display: flex;
   align-items: center;
 
   border-bottom: 1px solid ${GRAY[30]};
+
+  background-color: ${WHITE};
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     padding-left: 160px;

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -1,9 +1,11 @@
-import styled from "styled-components";
-import mock from "./mock";
-import AddDashBoard from "./AddDashBoard";
-import DashBoard from "./DashBoard";
-import LogoLink from "./LogoLink";
+import styled from 'styled-components';
+import mock from './mock';
+import AddDashBoard from './AddDashBoard';
+import DashBoard from './DashBoard';
+import LogoLink from './LogoLink';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import { Z_INDEX } from '@/styles/ZIndexStyles';
+import { WHITE } from '@/styles/ColorStyles';
 
 function SideMenu() {
   const data = mock.dashboards;
@@ -14,7 +16,12 @@ function SideMenu() {
       <AddDashBoard />
       <DashboardList>
         {data.map((dashboard, key) => (
-          <DashBoard key={dashboard.id} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} />
+          <DashBoard
+            key={dashboard.id}
+            color={dashboard.color}
+            title={dashboard.title}
+            createdByMe={dashboard.createdByMe}
+          />
         ))}
       </DashboardList>
     </Wrapper>
@@ -30,6 +37,13 @@ const Wrapper = styled.div`
   box-shadow: rgba(0, 0, 0, 0.15) 1.95px 0 0 0;
   display: flex;
   flex-direction: column;
+
+  position: fixed;
+  left: 0;
+  z-index: ${Z_INDEX.SideMenu_Wrapper};
+
+  background-color: ${WHITE};
+
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     width: 160px;
     height: 1666px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6533,6 +6533,37 @@
         "react-dom": "^16.8.0 || ^17 || ^18"
       }
     },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-responsive": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.2.tgz",
+      "integrity": "sha512-+4CCab7z8G8glgJoRjAwocsgsv6VA2w7JPxFWHRc7kvz8mec1/K5LutNC2MG28Mn8mu6+bu04XZxHv5gyfT7xQ==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",

--- a/pages/myboard.tsx
+++ b/pages/myboard.tsx
@@ -1,7 +1,183 @@
 import styled from 'styled-components';
+import Header from '@/components/common/Header/Second';
+import SideMenu from '@/components/common/SideMenu/SideMenu';
+import dashboardData from '@/components/common/SideMenu/mock';
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import Button from '@/components/common/Button';
+import { FONT_14 } from '@/styles/FontStyles';
+import InviteDash from '@/components/common/Table/InviteDash';
+
+const inviteData = {
+  cursorId: 123,
+  invitations: [
+    {
+      id: 1,
+      inviterUserId: 2,
+      teamId: 'team-10',
+      dashboard: {
+        title: '프로덕트 디자인',
+        id: 234,
+      },
+      invitee: {
+        nickname: '손동희',
+        id: 2,
+      },
+      inviteAccepted: true,
+      createdAt: '2023-12-20T04:38:51.003Z',
+      updatedAt: '2023-12-20T04:38:51.003Z',
+    },
+    {
+      id: 2,
+      inviterUserId: 3,
+      teamId: 'team-8',
+      dashboard: {
+        title: '새로운 기획 문서',
+        id: 234,
+      },
+      invitee: {
+        nickname: '안귀영',
+        id: 3,
+      },
+      inviteAccepted: true,
+      createdAt: '2023-12-20T04:38:51.003Z',
+      updatedAt: '2023-12-20T04:38:51.003Z',
+    },
+    {
+      id: 2,
+      inviterUserId: 3,
+      teamId: 'team-8',
+      dashboard: {
+        title: '유닛A',
+        id: 234,
+      },
+      invitee: {
+        nickname: '장혁',
+        id: 3,
+      },
+      inviteAccepted: true,
+      createdAt: '2023-12-20T04:38:51.003Z',
+      updatedAt: '2023-12-20T04:38:51.003Z',
+    },
+  ],
+};
 
 function Myboard() {
-  return <div>myboard 페이지입니다.</div>;
+  const data = dashboardData.dashboards;
+
+  return (
+    <>
+      <Header page="myboard">내 대시보드</Header>
+      <SideMenu />
+      <Body>
+        <Container>
+          <DashBoardSection>
+            <DashBoardList>
+              {data &&
+                data.map((dashboard) => (
+                  <ButtonWrapper>
+                    <Button type="dashboard" height="100%" fontSize="L" fontBold crown={dashboard.createdByMe}>
+                      {dashboard.title}
+                    </Button>
+                  </ButtonWrapper>
+                ))}
+              <ButtonWrapper>
+                <Button type="plain" height="100%" fontSize="L" chip fontBold>
+                  새로운 대시보드
+                </Button>
+              </ButtonWrapper>
+            </DashBoardList>
+            <PageWrapper>
+              <PageInfo>1 페이지 중 1</PageInfo>
+              <MoveButton>
+                <Button type="arrow-b" />
+                <Button type="arrow-f" />
+              </MoveButton>
+            </PageWrapper>
+          </DashBoardSection>
+          <InviteDash inviteList={inviteData} />
+        </Container>
+      </Body>
+    </>
+  );
 }
 
 export default Myboard;
+
+const Body = styled.body`
+  padding-top: 70px;
+  padding-left: 300px;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    padding-left: 160px;
+  }
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    padding-left: 67px;
+  }
+`;
+
+const Container = styled.div`
+  width: 100%;
+  max-width: 1022px;
+  padding: 40px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const DashBoardList = styled.div`
+  width: 100%;
+
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 13px;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    grid-template-columns: repeat(1, 1fr);
+    gap: 8px;
+  }
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  height: 70px;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    height: 68px;
+  }
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    height: 58px;
+  }
+`;
+
+const MoveButton = styled.div`
+  display: flex;
+`;
+
+const DashBoardSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const PageInfo = styled.div`
+  ${FONT_14};
+
+  display: flex;
+  align-items: center;
+`;
+
+const PageWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+`;

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -1,4 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
+import { GRAY } from './ColorStyles';
 
 const GlobalStyles = createGlobalStyle`
   @font-face {
@@ -15,6 +16,10 @@ const GlobalStyles = createGlobalStyle`
   html {
     font-family: "Pretendard";
     font-size: 62.5%;
+  }
+
+  html{
+    background-color: ${GRAY[10]};
   }
 
   html, body, div, span, h1, h2, h3, h4, h5, h6, p, 

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -8,13 +8,13 @@ const GlobalStyles = createGlobalStyle`
     font-style: normal;
   }
 
+  *{
+    box-sizing: border-box;
+  }
+
   html {
     font-family: "Pretendard";
     font-size: 62.5%;
-  }
-
-  body {
-    box-sizing: border-box;
   }
 
   html, body, div, span, h1, h2, h3, h4, h5, h6, p, 

--- a/styles/ZIndexStyles.ts
+++ b/styles/ZIndexStyles.ts
@@ -7,4 +7,6 @@ export const Z_INDEX = {
   modalFrame_Body: 900,
   profileImgList_Img: [1, 2, 3, 4],
   profileImgList_Rest: 5,
+  secondHeader_Body: 100,
+  SideMenu_Wrapper: 200,
 };


### PR DESCRIPTION
## 수정 내용

- myboard 페이지 UI 완성했습니다.
- Header 컴포넌트 z-index, position, background-color 등 수정했습니다.
- SideMenu 컴포넌트도 같은 부분 수정했습니다.

## 스크린샷
**pc**
<img width="1161" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/a625c58b-4de4-40d1-afb1-a1044aeb731f">

**tablet**
<img width="711" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/2fd3653b-afce-41f2-a90a-3e23cf44df9f">

**mobile**
<img width="380" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/4dcf2d08-1060-4034-83af-cc69debc8878">


## 기타
- 페이지 이동 부분은 일단 그냥 텍스트로 해놓았고, api 연결되면 다시 구현예정입니다.
- 버튼 컴포넌트는 따로 리팩 예정입니다.

## 지라 이슈 넘버
TT-68