### PR TITLE
[안희원] Button 컴포넌트 리팩토링

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -1,12 +1,11 @@
-import { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
-import { DEVICE_SIZE } from '@/styles/DeviceSize';
-import { BLACK, GRAY, VIOLET, WHITE } from '@/styles/ColorStyles';
+import { ReactNode } from 'react';
+import AddChip from '@/components/common/Chip/AddChip';
+import { BLACK, BLUE, GRAY, GREEN, ORANGE, PINK, PURPLE, VIOLET, WHITE } from '@/styles/ColorStyles';
 import { FONT_12, FONT_14, FONT_16, FONT_18 } from '@/styles/FontStyles';
-import PlusChip from '@/public/images/chip_add.svg';
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import ForwordIcon from '@/public/icon/arrow_forward.svg';
 import BackwordIcon from '@/public/icon/arrow_backward.svg';
-import GreenChip from '@/public/images/chip_green.svg';
 import Crown from '@/public/icon/crown.svg';
 
 const FONT_SIZE = {
@@ -22,95 +21,101 @@ const ROUND_SIZE = {
   S: '4px',
 };
 
-interface Props {
-  type: 'primary' | 'secondary' | 'plain' | 'arrow-b' | 'arrow-f' | 'dashboard';
-  width?: string;
-  height?: string;
+const CHIP_COLOR = {
+  green: GREEN,
+  purple: PURPLE,
+  orange: ORANGE,
+  blue: BLUE,
+  pink: PINK[1],
+};
+
+interface AddProps {
+  roundSize: 'L' | 'M' | 'S';
   fontSize?: 'XL' | 'L' | 'M' | 'S';
-  fontBold?: boolean;
-  roundSize?: 'L' | 'M' | 'S';
-  active?: boolean;
-  chip?: boolean;
-  chipColor?: 'green' | 'purple' | 'orange' | 'blue' | 'pink';
-  crown?: boolean;
-  position?: string;
-  right?: string;
-  bottom?: string;
+  isBoldFont?: boolean;
   children?: ReactNode;
 }
 
-/**
- * @param type primary: 보라배경 | secondary: 흰배경 & 보라글씨 | plain: 흰배경 & 검정글씨
- * @param width default: 100%
- * @param height default: 50px
- * @param fontSize XL: 18px | L: 16px | M: 14px | S: 12px
- * @param roundSize L: 8px | M: 6px | S: 4px
- * @param active 버튼 활성화 유무
- * @param chip '+' chip 유무
- * @param chipColor dashboard 타입 버튼에서 chip color
- * @param crown dashboard 타입 버튼에서 왕관 아이콘 유무
- * @param children 버튼에 들어갈 문구
- */
-function Button({
-  type,
-  width = '100%',
-  height = '50px',
-  fontSize = 'XL',
-  fontBold = false,
-  roundSize = 'L',
-  active = true,
-  chip = false,
-  position,
-  right,
-  bottom,
-  chipColor = 'green',
-  crown,
+interface DashBoardProps extends AddProps {
+  isOwner?: boolean;
+  chipColor: 'green' | 'purple' | 'orange' | 'blue' | 'pink';
+}
+
+interface BodyProps extends AddProps {
+  style: 'primary' | 'secondary' | 'outline';
+  isNotActive?: boolean;
+}
+
+function ButtonBody({
+  style,
+  isNotActive = false,
+  roundSize,
+  fontSize = 'L',
+  isBoldFont = false,
   children,
-}: Props) {
-  if (type === 'arrow-b' || type === 'arrow-f')
-    return (
-      <Arrow $type={type} $active={active}>
-        {type === 'arrow-b' ? <BackwordIcon /> : <ForwordIcon />}
-      </Arrow>
-    );
+}: BodyProps) {
   return (
     <Default
-      $type={type}
-      $width={width}
-      $height={height}
-      $active={active}
-      $fontSize={fontSize}
-      $fontBold={fontBold}
+      $style={style}
+      $isNotActive={isNotActive}
       $roundSize={roundSize}
-      $position={position}
-      $right={right}
-      $bottom={bottom}
+      $fontSize={fontSize}
+      $isBoldFont={isBoldFont}
     >
-      {type === 'dashboard' && <GreenChip />}
       {children}
-      {crown && <Crown />}
-      {type === 'dashboard' && <LinkIcon />}
-      {chip && <PlusChip />}
     </Default>
   );
 }
 
-export default Button;
+function AddButton({ roundSize, fontSize, isBoldFont, children }: AddProps) {
+  return (
+    <ButtonBody style="outline" roundSize={roundSize} fontSize={fontSize} isBoldFont={isBoldFont}>
+      <AddWrapper>
+        {children}
+        <AddChip />
+      </AddWrapper>
+    </ButtonBody>
+  );
+}
+
+function DashBoardButton({ isOwner = false, chipColor, roundSize, fontSize, isBoldFont, children }: DashBoardProps) {
+  return (
+    <ButtonBody style="outline" roundSize={roundSize} fontSize={fontSize} isBoldFont={isBoldFont}>
+      <DashBoardWrapper>
+        <Chip $color={chipColor} />
+        {children}
+        {isOwner && <CrownIcon />}
+        <LinkIcon />
+      </DashBoardWrapper>
+    </ButtonBody>
+  );
+}
+
+interface ArrowProps {
+  type: 'left' | 'right';
+  isNotActive?: boolean;
+}
+
+function ArrowButton({ type, isNotActive = false }: ArrowProps) {
+  return (
+    <Arrow $type={type} $isNotActive={isNotActive}>
+      {type === 'left' ? <BackwordIcon /> : <ForwordIcon />}
+    </Arrow>
+  );
+}
+
+export const Button = Object.assign({
+  Plain: ButtonBody,
+  Add: AddButton,
+  DashBoard: DashBoardButton,
+  Arrow: ArrowButton,
+});
 
 const inactive = css`
   background-color: ${GRAY[40]};
 
   &:hover {
     background-color: ${GRAY[40]};
-    cursor: not-allowed;
-  }
-`;
-
-const arrowInactive = css`
-  opacity: 55%;
-
-  &:hover {
-    background-color: ${WHITE};
     cursor: not-allowed;
   }
 `;
@@ -136,7 +141,7 @@ const secondary = css`
   }
 `;
 
-const plain = css`
+const outline = css`
   ${secondary};
 
   color: ${BLACK[2]};
@@ -147,44 +152,85 @@ const plain = css`
 `;
 
 const Default = styled.button<{
-  $type: string;
-  $width: string;
-  $height: string;
-  $fontSize: 'XL' | 'L' | 'M' | 'S';
-  $fontBold: boolean;
-  $active: boolean;
+  $style: 'primary' | 'secondary' | 'outline';
+  $isNotActive: boolean;
   $roundSize: 'L' | 'M' | 'S';
-  $position: string | undefined;
-  $right: string | undefined;
-  $bottom: string | undefined;
+  $fontSize: 'XL' | 'L' | 'M' | 'S';
+  $isBoldFont: boolean;
 }>`
-  width: ${({ $width }) => $width};
-  height: ${({ $height }) => $height};
-  /* padding: 0 20px 0; */
-
-  display: flex;
-  justify-content: ${({ $type }) => ($type === 'dashboard' ? 'flex-start' : 'center')};
-  align-items: center;
-  gap: 12px;
-
-  position: ${(props) => (props.$position ? props.$position : 'relative')};
-  ${(props) => props.$right && `right: ${props.$right}`};
-  ${(props) => props.$bottom && `bottom: ${props.$bottom}`};
+  width: 100%;
+  height: 100%;
 
   border-radius: ${(props) => ROUND_SIZE[`${props.$roundSize}`]};
 
   ${(props) => FONT_SIZE[`${props.$fontSize}`]};
-  font-weight: ${({ $fontBold }) => ($fontBold ? '700' : null)};
+  font-weight: ${(props) => (props.$isBoldFont ? '700' : null)};
 
-  ${({ $type }) => {
-    if ($type === 'primary') return primary;
-    if ($type === 'secondary') return secondary;
-    if ($type === 'plain' || 'dashboard') return plain;
-  }};
-  ${({ $active }) => ($active ? null : inactive)}
+  ${(props) => {
+    if (props.$isNotActive) return inactive;
+    if (props.$style === 'primary') return primary;
+    if (props.$style === 'secondary') return secondary;
+    if (props.$style === 'outline') return outline;
+  }}
 `;
 
-const Arrow = styled.button<{ $type: string; $active: boolean }>`
+const AddWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+`;
+
+const DashBoardWrapper = styled.div`
+  padding: 0 20px;
+
+  display: flex;
+  align-items: center;
+
+  position: relative;
+`;
+
+const Chip = styled.div<{ $color: 'green' | 'purple' | 'orange' | 'blue' | 'pink' }>`
+  margin-right: 16px;
+
+  width: 8px;
+  height: 8px;
+
+  background-color: ${(props) => `${CHIP_COLOR[props.$color]}`};
+  border-radius: 100%;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-right: 12px;
+  }
+`;
+
+const LinkIcon = styled(ForwordIcon)`
+  position: absolute;
+  right: 20px;
+`;
+
+const CrownIcon = styled(Crown)`
+  margin-left: 8px;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-left: 6px;
+  }
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-left: 4px;
+  }
+`;
+
+const arrowInactive = css`
+  opacity: 55%;
+
+  &:hover {
+    background-color: ${WHITE};
+    cursor: not-allowed;
+  }
+`;
+
+const Arrow = styled.button<{ $type: string; $isNotActive: boolean }>`
   width: 40px;
   height: 40px;
 
@@ -192,17 +238,12 @@ const Arrow = styled.button<{ $type: string; $active: boolean }>`
   align-items: center;
   justify-content: center;
 
-  ${plain};
-  border-radius: ${(props) => (props.$type === 'arrow-f' ? ' 0 4px 4px 0' : '4px 0 0 4px')};
-  ${(props) => (props.$active ? null : arrowInactive)};
+  ${outline};
+  border-radius: ${(props) => (props.$type === 'right' ? ' 0 4px 4px 0' : '4px 0 0 4px')};
+  ${(props) => (props.$isNotActive ? arrowInactive : null)};
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     width: 36px;
     height: 36px;
   }
-`;
-
-const LinkIcon = styled(ForwordIcon)`
-  position: absolute;
-  right: 20px;
 `;

--- a/components/common/Chip/AddChip.tsx
+++ b/components/common/Chip/AddChip.tsx
@@ -7,24 +7,24 @@ function AddChip() {
     <Container>
       <StyledAddFilloIcon />
     </Container>
-  )
+  );
 }
 
 export default AddChip;
 
 const Container = styled.div`
-  width: 30px;
-  height: 30px;
+  width: 22px;
+  height: 22px;
   padding: 3px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: #F1EFFD;
+  background-color: #f1effd;
   border-radius: 4px;
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
-    width: 22px;
-    height: 22px;
+    width: 20px;
+    height: 20px;
   }
 `;
 

--- a/hooks/useForm.tsx
+++ b/hooks/useForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 import Input from '@/components/common/Input/Input';
-import Button from '@/components/common/Button';
+import { Button } from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
 import { FONT_16, FONT_20 } from '@/styles/FontStyles';
 import { BLACK } from '@/styles/ColorStyles';
@@ -10,9 +10,9 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 
 function UserForm({ type }) {
   const [password, setPassword] = useState('');
-  
+
   const isSignup = type === 'signup';
-  
+
   return (
     <Root>
       <Container>
@@ -21,15 +21,17 @@ function UserForm({ type }) {
         <Form>
           <Input type="email" />
           {isSignup && <Input type="nickname" />}
-          <Input type="password" isPassword/>
-          {isSignup && <Input type="passwordConfirm" isPassword passwordCheck={password}/>}
+          <Input type="password" isPassword />
+          {isSignup && <Input type="passwordConfirm" isPassword passwordCheck={password} />}
           {isSignup && <Checkbox label="이용약관에 동의합니다." />}
-          <Button type="primary" fontSize="XL" roundSize="L" active={false}>{isSignup ? '가입하기' : '로그인'}</Button>
+          <ButtonWrapper>
+            <Button.Plain style="primary" fontSize="XL" roundSize="L" isNotActive>
+              {isSignup ? '가입하기' : '로그인'}
+            </Button.Plain>
+          </ButtonWrapper>
           <Wrapper>
-            {isSignup ? '이미 가입하셨나요?' : '회원이 아니신가요?'}{" "}
-            <Link href={isSignup ? "/login" : "/signup"}>
-              {isSignup ? '로그인하기' : '회원가입하기'}
-            </Link>
+            {isSignup ? '이미 가입하셨나요?' : '회원이 아니신가요?'}{' '}
+            <Link href={isSignup ? '/login' : '/signup'}>{isSignup ? '로그인하기' : '회원가입하기'}</Link>
           </Wrapper>
         </Form>
       </Container>
@@ -40,19 +42,19 @@ function UserForm({ type }) {
 export default UserForm;
 
 const Root = styled.div`
-    height: 100vh;
+  height: 100vh;
 `;
 
 const Container = styled.div`
-    width: 100%;
-    max-width: 520px;
-    height: 100%;
-    margin: 0 auto;
-    padding: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
+  width: 100%;
+  max-width: 520px;
+  height: 100%;
+  margin: 0 auto;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
 `;
 
 const Logo = styled.img`
@@ -65,20 +67,25 @@ const Logo = styled.img`
 `;
 
 const Word = styled.span`
-    width: 189px;
-    height: 24px;
-    margin: 10px auto 38px;
-    text-align: center;
-    ${FONT_20};
+  width: 189px;
+  height: 24px;
+  margin: 10px auto 38px;
+  text-align: center;
+  ${FONT_20};
 `;
 
 const Form = styled.form`
-    width: 100%;
+  width: 100%;
 `;
 
 const Wrapper = styled.div`
-    margin-top: 24px;
-    text-align: center;
-    ${FONT_16};
-    color: ${BLACK[2]};
+  margin-top: 24px;
+  text-align: center;
+  ${FONT_16};
+  color: ${BLACK[2]};
+`;
+
+const ButtonWrapper = styled.div`
+  width: 100%;
+  height: 50px;
 `;

--- a/pages/myboard.tsx
+++ b/pages/myboard.tsx
@@ -43,7 +43,7 @@ const inviteData = {
       updatedAt: '2023-12-20T04:38:51.003Z',
     },
     {
-      id: 2,
+      id: 3,
       inviterUserId: 3,
       teamId: 'team-8',
       dashboard: {
@@ -74,7 +74,7 @@ function Myboard() {
             <DashBoardList>
               {data &&
                 data.map((dashboard) => (
-                  <ButtonWrapper>
+                  <ButtonWrapper key={dashboard.id}>
                     <Button type="dashboard" height="100%" fontSize="L" fontBold crown={dashboard.createdByMe}>
                       {dashboard.title}
                     </Button>
@@ -103,7 +103,7 @@ function Myboard() {
 
 export default Myboard;
 
-const Body = styled.body`
+const Body = styled.div`
   padding-top: 70px;
   padding-left: 300px;
 

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -11,10 +11,10 @@ const GlobalStyles = createGlobalStyle`
   
   *{
     box-sizing: border-box;
+    font-family: "Pretendard";
   }
 
   html {
-    font-family: "Pretendard";
     font-size: 62.5%;
   }
 


### PR DESCRIPTION
## 수정 내용

- 드!!디어 Button 컴포넌트를 리팩토링 완료했습니다!

## 스크린샷
<img width="600" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/229419b1-5b7a-48c3-95a6-c0dfd97f2015">


## 사용 방법
![image](https://github.com/like-tenten/tenten/assets/103186362/143e2fbd-8c17-492e-a18e-08b1458716f4)
_모든 버튼 공통 prop : roundSize, fontSize, isBoldFont, children_
- Button의 타입으로는 크게 "**Plain**", "**Add**", "**DashBoard**", "**Arrow**"가 있습니다.
- 각 타입은 `<Button.Plain></Button.Plain>` 형식으로 사용하면 됩니다. (사진 참고)
- 버튼 문구는 children으로 넣으면 됩니다.
- font에 bold를 적용하고 싶다면 `isFontBold` prop을 추가하면 됩니다.
- **크기/반응형은 사용처에서 버튼 바깥에 Wrapper를 씌워서 적용해주세요.** ⭐⭐⭐⭐⭐
- **반응형에 따라 font-size를 조정하고 싶은 경우, 사용처에서 children에 직접 적용해주세요** ⭐⭐⭐

### Plain
_prop : style, isNotActive_
- 버튼 내부에 글씨만 있는 경우 사용
- 버튼 내부를 직접 커스텀하고 싶은 경우 사용 (children에 직접 넣으면 됩니다!)
- Plain 타입은 `style` prop을 이용해 스타일을 설정할 수 있습니다.
- 버튼을 막고싶다면, `isNotActive` prop을 추가하면 됩니다.
**style의 타입**
- primary : 보라색 배경 && 흰색 글씨
- secondary : 흰색 배경 && 보라색 글씨
- outline : 흰색 배경 && 검정색 글씨

### Add
- '+' 모양 chip이 추가된 버튼

### DashBoard
_prop : isOwner, chipColor_
- DashBoard 바로가기 버튼
- crown 아이콘을 추가하려면 `isOwner` prop을 추가하면 됩니다.
- `chipColor` type은 Button.tsx 참고

### Arrow
_prop : type, isNotActive_
- 화살표 버튼
- `type`의 type : 'left' | 'right'

자동 완성이 안돼서 type이나 prop값 사용하는게 어려울 수도 있을 것 같아요ㅠㅠ! (제송..합니다..)
최대한 자세히 사용법 적어보려고 노력하긴 했는데.. 
사용하다 어렵거나, 궁금한거 있으시면 질문해주세요!!

TT-81 TT-42