### PR TITLE
[이규호] Chip 컴포넌트 모바일 사이즈에서 체크된 것만 보이도록 수정

### DIFF
--- a/components/common/Chip/AddChip.tsx
+++ b/components/common/Chip/AddChip.tsx
@@ -4,15 +4,15 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 
 function AddChip() {
   return (
-    <Container>
+    <StyledContainer>
       <StyledAddFilloIcon />
-    </Container>
+    </StyledContainer>
   );
 }
 
 export default AddChip;
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   width: 22px;
   height: 22px;
   padding: 3px;

--- a/components/common/Chip/ChipColor.tsx
+++ b/components/common/Chip/ChipColor.tsx
@@ -18,15 +18,15 @@ interface Props {
 function ChipColor({ backgroundColor, fontColor, text }: Props) {
 
   return (
-    <Container backgroundColor={backgroundColor} fontColor={fontColor}>
+    <StyledContainer backgroundColor={backgroundColor} fontColor={fontColor}>
       {text}
-    </Container>
+    </StyledContainer>
   );
 };
 
 export default ChipColor;
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   padding: 4px 6px;
   display: inline-block;
   background-color: ${props => props.backgroundColor};

--- a/components/common/Chip/ColumnNameChip.tsx
+++ b/components/common/Chip/ColumnNameChip.tsx
@@ -9,16 +9,16 @@ interface Props {
 
 function ColumnNameChip({content}: Props) {
   return (
-    <Container>
+    <StyledContainer>
         <VioletChipIcon />
-        <Content>{content}</Content>
-    </Container>
+        <StyledContent>{content}</StyledContent>
+    </StyledContainer>
   )
 }
 
 export default ColumnNameChip;
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   padding: 4px 8px;
   display: inline-flex;
   align-items: center;
@@ -27,7 +27,7 @@ const Container = styled.div`
   border-radius: 11px;
 `;
 
-const Content = styled.span`
+const StyledContent = styled.span`
   text-align: center;
   color: #5534DA;
   ${FONT_12};

--- a/components/common/Chip/CountChip.tsx
+++ b/components/common/Chip/CountChip.tsx
@@ -6,15 +6,15 @@ interface Props {
 
 function CountChip({number}: Props) {
   return (
-    <Container>
-      <Content>{number}</Content>
-    </Container>
+    <StyledContainer>
+      <StyledContent>{number}</StyledContent>
+    </StyledContainer>
   )
 }
 
 export default CountChip;
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   padding: 3px 6px;
   display: inline-flex;
   align-items: center;
@@ -22,6 +22,6 @@ const Container = styled.div`
   border-radius: 4px;
 `;
 
-const Content = styled.span`
+const StyledContent = styled.span`
   color: #787486;
 `;

--- a/components/common/Chip/DashBoardColor.tsx
+++ b/components/common/Chip/DashBoardColor.tsx
@@ -17,31 +17,31 @@ function DashBoardColor({ selectedColor, setSelectedColor }: Props) {
   const colors = [GREEN, PURPLE, ORANGE, BLUE, PINK[1]];
 
   return (
-    <Container>
+    <StyledContainer>
       {colors.map((color) => (
-        <ColorBox
+        <StyledColorBox
           key={color}
           onClick={() => setSelectedColor(color)}
           color={color}
           isSelected={selectedColor === color}
         >
           {selectedColor === color && <DoneIcon />}
-        </ColorBox>
+        </StyledColorBox>
       ))}
-    </Container>
+    </StyledContainer>
   );
 }
 
 export default DashBoardColor;
 
-const Container = styled.div`
+const StyledContainer = styled.div`
   display: inline-flex;
   justify-content: center;
   align-items: center;
   gap: 10px;
 `;
 
-const ColorBox = styled.div<{ isSelected: boolean; color: string }>`
+const StyledColorBox = styled.div<{ isSelected: boolean; color: string }>`
   width: 30px;
   height: 30px;
   display: flex;
@@ -54,5 +54,8 @@ const ColorBox = styled.div<{ isSelected: boolean; color: string }>`
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     width: 28px;
     height: 28px;
+
+    display: ${(props) => (props.isSelected ? 'flex' : 'none')};
+  }
   }
 `;

--- a/components/common/Chip/DashBoardColor.tsx
+++ b/components/common/Chip/DashBoardColor.tsx
@@ -57,5 +57,4 @@ const StyledColorBox = styled.div<{ isSelected: boolean; color: string }>`
 
     display: ${(props) => (props.isSelected ? 'flex' : 'none')};
   }
-  }
 `;


### PR DESCRIPTION
## 수정 내용

- 모바일 사이즈에서 체크된 것만 보이도록 수정했습니다.

## (선택) 스크린샷
<img width="239" alt="33" src="https://github.com/like-tenten/tenten/assets/101032270/a1f107e1-e8ab-4298-b80a-8b312d1618a4">
<img width="214" alt="44" src="https://github.com/like-tenten/tenten/assets/101032270/c7fc04e0-a64a-4e90-a58f-5287f60dda1e">


## 기타
