### PR TITLE
[송규경] 6개 Modal(컬럼 관리, 생성, 경고 3종, 새로운 대시보드) 구현 완료

### DIFF
--- a/components/common/Button/ButtonBase.tsx
+++ b/components/common/Button/ButtonBase.tsx
@@ -13,11 +13,12 @@ export interface BaseProps {
   roundSize: 'L' | 'M' | 'S';
   isNotActive?: boolean;
   children?: ReactNode;
+  onClick: () => void;
 }
 
-function ButtonBase({ style = 'outline', roundSize, isNotActive = false, children }: BaseProps) {
+function ButtonBase({ style = 'outline', roundSize, isNotActive = false, children, onClick }: BaseProps) {
   return (
-    <StyledButtonBase $style={style} $isNotActive={isNotActive} $roundSize={roundSize}>
+    <StyledButtonBase $style={style} $isNotActive={isNotActive} $roundSize={roundSize} onClick={onClick}>
       {children}
     </StyledButtonBase>
   );

--- a/components/common/Chip/DashBoardColor.tsx
+++ b/components/common/Chip/DashBoardColor.tsx
@@ -1,3 +1,4 @@
+import { SetStateAction } from 'react';
 import styled from 'styled-components';
 import DoneIcon from '@/public/icon/done_Fillo.svg';
 import { GREEN, PURPLE, ORANGE, BLUE, PINK } from '@/styles/ColorStyles';
@@ -5,7 +6,7 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 
 interface Props {
   selectedColor: string;
-  setSelectedColor: (color: string) => void;
+  setSelectedColor: (value: SetStateAction<string>) => void;
 }
 
 /**
@@ -22,8 +23,8 @@ function DashBoardColor({ selectedColor, setSelectedColor }: Props) {
         <StyledColorBox
           key={color}
           onClick={() => setSelectedColor(color)}
-          color={color}
-          isSelected={selectedColor === color}
+          $color={color}
+          $isSelected={selectedColor === color}
         >
           {selectedColor === color && <DoneIcon />}
         </StyledColorBox>
@@ -41,13 +42,13 @@ const StyledContainer = styled.div`
   gap: 10px;
 `;
 
-const StyledColorBox = styled.div<{ isSelected: boolean; color: string }>`
+const StyledColorBox = styled.div<{ $isSelected: boolean; $color: string }>`
   width: 30px;
   height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: ${(props) => props.color};
+  background-color: ${(props) => props.$color};
   cursor: pointer;
   border-radius: 50%;
 
@@ -55,6 +56,6 @@ const StyledColorBox = styled.div<{ isSelected: boolean; color: string }>`
     width: 28px;
     height: 28px;
 
-    display: ${(props) => (props.isSelected ? 'flex' : 'none')};
+    display: ${(props) => (props.$isSelected ? 'flex' : 'none')};
   }
 `;

--- a/components/common/DropDown/DropDown.tsx
+++ b/components/common/DropDown/DropDown.tsx
@@ -71,20 +71,22 @@ function DropDown({ type, initialStatus, initialPerson }: Props) {
 
   return (
     <>
-      <Wrapper ref={containerRef} $type={type}>
+      <StyledWrapper ref={containerRef} $type={type}>
         {(type === 'status' || type === 'person') && (
-          <MainBox $isOpen={isDropDownOpen} $type={type} onClick={handleAnchorRefClick}>
+          <StyledMainBox $isOpen={isDropDownOpen} $type={type} onClick={handleAnchorRefClick}>
             {type === 'status' && value.status === 'ToDo' && <ToDoLargeIcon />}
             {type === 'status' && value.status === 'OnProgress' && <OnProgressLargeIcon />}
             {type === 'status' && value.status === 'Done' && <DoneLargeIcon />}
             {type === 'person' && (
-              <Input value={value.person} onChange={handleInputChange} placeholder="이름을 입력해 주세요" />
+              <StyledInput value={value.person} onChange={handleInputChange} placeholder="이름을 입력해 주세요" />
             )}
-            {type === 'person' && !value.person ? null : <ArrowIcon $type={type} onClick={handleArrowIconClick} />}
-          </MainBox>
+            {type === 'person' && !value.person ? null : (
+              <StyledArrowIcon $type={type} onClick={handleArrowIconClick} />
+            )}
+          </StyledMainBox>
         )}
-        {type === 'kebab' && <KebabIcon onClick={handleAnchorRefClick} />}
-      </Wrapper>
+        {type === 'kebab' && <StyledKebabIcon onClick={handleAnchorRefClick} />}
+      </StyledWrapper>
       {isDropDownOpen && (
         <DropDownList
           anchorRef={containerRef}
@@ -100,14 +102,14 @@ function DropDown({ type, initialStatus, initialPerson }: Props) {
 
 export default DropDown;
 
-const Wrapper = styled.div<{ $type: string }>`
+const StyledWrapper = styled.div<{ $type: string }>`
   width: ${({ $type }) => ($type === 'kebab' ? '28px' : '217px')};
   display: flex;
   flex-direction: column;
   position: relative;
 `;
 
-const MainBox = styled.div<{ $isOpen: boolean; $type: string }>`
+const StyledMainBox = styled.div<{ $isOpen: boolean; $type: string }>`
   width: 217px;
   height: 48px;
   padding: 10px 15px;
@@ -120,7 +122,7 @@ const MainBox = styled.div<{ $isOpen: boolean; $type: string }>`
   ${({ $type }) => $type === 'status' && `cursor: pointer`};
 `;
 
-const Input = styled.input`
+const StyledInput = styled.input`
   width: 100%;
 
   &::placeholder {
@@ -128,12 +130,12 @@ const Input = styled.input`
   }
 `;
 
-const ArrowIcon = styled(ArrowDropDownIcon)<{ $type: string }>`
+const StyledArrowIcon = styled(ArrowDropDownIcon)<{ $type: string }>`
   position: ${({ $type }) => ($type === 'status' ? 'absolute' : 'static')};
   right: 10px;
   cursor: pointer;
 `;
 
-const KebabIcon = styled(MoreIcon)`
+const StyledKebabIcon = styled(MoreIcon)`
   cursor: pointer;
 `;

--- a/components/common/DropDown/DropDownList.tsx
+++ b/components/common/DropDown/DropDownList.tsx
@@ -3,6 +3,9 @@ import styled from 'styled-components';
 import { GRAY, VIOLET } from '@/styles/ColorStyles';
 import CheckIcon from '@/public/icon/dropdown_check.svg';
 import ModalPortal from '../Modal/ModalPortal';
+import AlertModal from '../Modal/AlertModal';
+import { modalType } from '@/lib/types/zustand';
+import { useStore } from '@/context/stores';
 import { statusCollection, userCollection } from '@/lib/constants/statusCollection';
 import ToDoLargeIcon from '@/public/icon/todo_large.svg';
 import OnProgressLargeIcon from '@/public/icon/onProgress_large.svg';
@@ -22,6 +25,8 @@ interface Props {
 }
 
 function DropDownList({ anchorRef, setValue, value, type, handleDropDownClose }: Props) {
+  const modal = useStore((state) => state.modals);
+  const showModal = useStore((state) => state.showModal);
   const filteredUser = userCollection.filter((item) => item.name.includes(value.person));
 
   const handleClickOption = (value: string) => {
@@ -40,44 +45,50 @@ function DropDownList({ anchorRef, setValue, value, type, handleDropDownClose }:
     handleDropDownClose();
   };
 
+  const handleButtonClick = (type: modalType) => {
+    if (modal.includes(type)) return;
+    showModal(type);
+  };
+
   return (
     <ModalPortal container={anchorRef.current}>
-      <WrapperUl $isUser={filteredUser.length} $type={type}>
+      <StyledWrapperUl $isUser={filteredUser.length} $type={type}>
         {type === 'status' &&
           statusCollection.map((item) => {
             return (
-              <WrapperLi key={item.id} onClick={() => handleClickOption(item.type)}>
-                {value.status === item.type ? <CheckIcon /> : <TransparentBox />}
+              <StyledWrapperLi key={item.id} onClick={() => handleClickOption(item.type)}>
+                {value.status === item.type ? <CheckIcon /> : <StyledTransparentBox />}
                 {item.type === 'ToDo' && <ToDoLargeIcon />}
                 {item.type === 'OnProgress' && <OnProgressLargeIcon />}
                 {item.type === 'Done' && <DoneLargeIcon />}
-              </WrapperLi>
+              </StyledWrapperLi>
             );
           })}
         {type === 'person' &&
           value.person &&
           filteredUser.map((item) => {
             return (
-              <WrapperLi key={item.id} onClick={() => handleClickOption(item.name)}>
-                {value.person === item.name ? <CheckIcon /> : <TransparentBox />}
+              <StyledWrapperLi key={item.id} onClick={() => handleClickOption(item.name)}>
+                {value.person === item.name ? <CheckIcon /> : <StyledTransparentBox />}
                 {item.name}
-              </WrapperLi>
+              </StyledWrapperLi>
             );
           })}
         {type === 'kebab' && (
           <>
-            <ModalPopLi>수정하기</ModalPopLi>
-            <ModalPopLi>삭제하기</ModalPopLi>
+            <StyledModalPopLi>수정하기</StyledModalPopLi>
+            <StyledModalPopLi onClick={() => handleButtonClick('deleteCardAlert')}>삭제하기</StyledModalPopLi>
+            {modal[modal.length - 1] === 'deleteCardAlert' && <AlertModal type="deleteCardAlert" />}
           </>
         )}
-      </WrapperUl>
+      </StyledWrapperUl>
     </ModalPortal>
   );
 }
 
 export default DropDownList;
 
-const WrapperUl = styled.ul<{ $isUser: number; $type: string }>`
+const StyledWrapperUl = styled.ul<{ $isUser: number; $type: string }>`
   width: ${({ $type }) => ($type === 'kebab' ? '93px' : '217px')};
   padding: ${({ $type }) => ($type === 'kebab' ? '6px' : null)};
   position: absolute;
@@ -91,7 +102,7 @@ const WrapperUl = styled.ul<{ $isUser: number; $type: string }>`
   ${({ $isUser }) => $isUser || `display: none`};
 `;
 
-const WrapperLi = styled.li`
+const StyledWrapperLi = styled.li`
   width: 100%;
   height: 45px;
   padding: 0 10px;
@@ -107,12 +118,12 @@ const WrapperLi = styled.li`
   }
 `;
 
-const TransparentBox = styled.div`
+const StyledTransparentBox = styled.div`
   width: 22px;
   height: 22px;
 `;
 
-const ModalPopLi = styled.div`
+const StyledModalPopLi = styled.div`
   width: 100%;
   height: 32px;
   display: flex;

--- a/components/common/Input/Calendar.tsx
+++ b/components/common/Input/Calendar.tsx
@@ -27,7 +27,7 @@ function Calendar({ placeholder }: Props) {
   };
 
   return (
-    <CalendarBox>
+    <StyledCalendarBox>
       <CalendarIcon />
       <StyledDatePicker
         selected={selectDate}
@@ -40,13 +40,13 @@ function Calendar({ placeholder }: Props) {
         showTimeSelect
         placeholderText={placeholder}
       />
-    </CalendarBox>
+    </StyledCalendarBox>
   );
 }
 
 export default Calendar;
 
-const CalendarBox = styled.div`
+const StyledCalendarBox = styled.div`
   width: 450px;
   height: 50px;
   padding: 15px 16px;

--- a/components/common/Input/Input.tsx
+++ b/components/common/Input/Input.tsx
@@ -51,7 +51,7 @@ function Input({
 
   return (
     <>
-      <StyledContainer $type={type === 'title' || type === 'tag' ? true : false}>
+      <StyledContainer $type={type === 'email' || type === 'password' || type === 'passwordConfirm' ? true : false}>
         <StyledLabel
           $bold={type === 'dueDate' || type === 'title' || type === 'tag' || type === 'nickname' ? true : false}
           htmlFor={type}
@@ -65,7 +65,12 @@ function Input({
             id={type}
             placeholder={placeholder}
             type={
-              type === 'email' || type === 'title' || type === 'tag' || type === 'nickname'
+              type === 'email' ||
+              type === 'title' ||
+              type === 'tag' ||
+              type === 'nickname' ||
+              type === 'name' ||
+              type === 'dashboard'
                 ? 'text'
                 : passwordInvisible
                   ? 'password'
@@ -101,12 +106,12 @@ const StyledIcon = css`
 `;
 
 const StyledContainer = styled.div<{ $type: boolean }>`
-  width: ${({ $type }) => ($type ? '450px' : '520px')};
+  width: ${({ $type }) => ($type ? '520px' : '100%')};
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  margin-bottom: 16px;
+  ${({ $type }) => $type && 'margin-bottom: 16px'};
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     width: 100%;
   }

--- a/components/common/Input/Input.tsx
+++ b/components/common/Input/Input.tsx
@@ -11,7 +11,7 @@ import EyeOn from '@/public/icon/visibility.svg';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 
 interface InputProps {
-  type: 'email' | 'password' | 'passwordConfirm' | 'title' | 'dueDate' | 'tag' | 'nickname';
+  type: 'email' | 'password' | 'passwordConfirm' | 'title' | 'dueDate' | 'tag' | 'nickname' | 'name' | 'dashboard';
   isPassword?: boolean;
   passwordCheck?: string;
   setPassword?: (value: string) => void;

--- a/components/common/Modal/AlertModal.tsx
+++ b/components/common/Modal/AlertModal.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import { modalType } from '@/lib/types/zustand';
+import ModalFrame from './ModalFrame';
+import { BLACK } from '@/styles/ColorStyles';
+import { FONT_18 } from '@/styles/FontStyles';
+
+interface Props {
+  type: modalType;
+}
+
+function AlertModal({ type }: Props) {
+  const getErrorMsg = (type: modalType): string | undefined => {
+    let errorMsg;
+    switch (type) {
+      case 'incorrectPWAlert':
+        errorMsg = '비밀번호가 일치하지 않습니다.';
+        break;
+      case 'deleteColumnAlert':
+        errorMsg = '컬럼의 모든 카드가 삭제됩니다.';
+        break;
+      case 'deleteCardAlert':
+        errorMsg = '현재 카드가 삭제됩니다.';
+        break;
+      default:
+        break;
+    }
+    return errorMsg;
+  };
+
+  const handleButtonClick = () => {};
+
+  return (
+    <ModalFrame type={type} title={''} height="High" btnFnc={handleButtonClick}>
+      <ErrorMsgBox>
+        <ErrorMsg>{getErrorMsg(type)}</ErrorMsg>
+      </ErrorMsgBox>
+    </ModalFrame>
+  );
+}
+
+export default AlertModal;
+
+const ErrorMsgBox = styled.div`
+  padding: 20px 0;
+`;
+
+const ErrorMsg = styled.h1`
+  ${FONT_18};
+  color: ${BLACK[2]};
+  text-align: center;
+`;

--- a/components/common/Modal/ColumnModal.tsx
+++ b/components/common/Modal/ColumnModal.tsx
@@ -1,0 +1,51 @@
+import styled from 'styled-components';
+import { modalType } from '@/lib/types/zustand';
+import { useStore } from '@/context/stores';
+import Input from '../Input/Input';
+import ModalFrame from './ModalFrame';
+import { FONT_14 } from '@/styles/FontStyles';
+import { GRAY } from '@/styles/ColorStyles';
+import AlertModal from './AlertModal';
+
+interface Props {
+  type: modalType;
+}
+
+function ColumnModal({ type }: Props) {
+  const modal = useStore((state) => state.modals);
+  const showModal = useStore((state) => state.showModal);
+
+  const handleDeleteClick = (type: modalType) => {
+    if (modal.includes(type)) return;
+    showModal(type);
+  };
+
+  const handleButtonClick = () => {};
+
+  return (
+    <ModalFrame
+      type={type}
+      title={type === 'createColumn' ? '새 컬럼 생성' : '컬럼 관리'}
+      height="Mid"
+      btnFnc={handleButtonClick}
+    >
+      <Input type="name" />
+      {type === 'manageColumn' && (
+        <StyledDeleteButton onClick={() => handleDeleteClick('deleteColumnAlert')}>삭제하기</StyledDeleteButton>
+      )}
+      {modal[modal.length - 1] === 'deleteColumnAlert' && <AlertModal type="deleteColumnAlert" />}
+    </ModalFrame>
+  );
+}
+
+export default ColumnModal;
+
+const StyledDeleteButton = styled.button`
+  position: absolute;
+  bottom: -75px;
+  ${FONT_14};
+  font-weight: 400;
+  color: ${GRAY[40]};
+  text-decoration-line: underline;
+  background-color: white;
+`;

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -1,0 +1,19 @@
+import { modalType } from '@/lib/types/zustand';
+import Input from '../Input/Input';
+import ModalFrame from './ModalFrame';
+
+interface Props {
+  type: modalType;
+}
+
+function DashboardModal({ type }: Props) {
+  const handleButtonClick = () => {};
+
+  return (
+    <ModalFrame type={type} title={'새로운 대시보드'} height="Low" btnFnc={handleButtonClick}>
+      <Input type="dashboard" />
+    </ModalFrame>
+  );
+}
+
+export default DashboardModal;

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -1,19 +1,35 @@
+import { useState } from 'react';
+import styled from 'styled-components';
 import { modalType } from '@/lib/types/zustand';
 import Input from '../Input/Input';
 import ModalFrame from './ModalFrame';
+import { GREEN, PURPLE, ORANGE, BLUE, PINK } from '@/styles/ColorStyles';
+import DashBoardColor from '../Chip/DashBoardColor';
 
 interface Props {
   type: modalType;
 }
 
 function DashboardModal({ type }: Props) {
+  const colors = [GREEN, PURPLE, ORANGE, BLUE, PINK[1]];
+  const initialColor = colors[0];
+  const [color, setColor] = useState(initialColor);
   const handleButtonClick = () => {};
 
   return (
     <ModalFrame type={type} title={'새로운 대시보드'} height="Low" btnFnc={handleButtonClick}>
       <Input type="dashboard" />
+      <StyledColorWrapper>
+        <DashBoardColor selectedColor={color} setSelectedColor={setColor} />
+      </StyledColorWrapper>
     </ModalFrame>
   );
 }
 
 export default DashboardModal;
+
+const StyledColorWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  margin-top: 10px;
+`;

--- a/components/common/Modal/ModalFrame.tsx
+++ b/components/common/Modal/ModalFrame.tsx
@@ -1,81 +1,138 @@
 import { ReactNode } from 'react';
 import styled from 'styled-components';
-import { Z_INDEX } from '@/styles/ZIndexStyles';
 import useNotScroll from '@/hooks/useNotScroll';
-import useModal from '@/hooks/useModal';
+import { useStore } from '@/context/stores';
+import CloseIcon from '@/public/icon/crown.svg';
 import ModalPortal from './ModalPortal';
-import CloseIcon from "@/public/icon/crown.svg"
-
-const { modalFrame_Mask, modalFrame_Body } = Z_INDEX;
+import Button from '../Button';
+import { Z_INDEX } from '@/styles/ZIndexStyles';
+import { FONT_14, FONT_24_B } from '@/styles/FontStyles';
+import { BLACK } from '@/styles/ColorStyles';
+import { modalType } from '@/lib/types/zustand';
 
 interface Props {
+  height: 'Low' | 'Mid' | 'High';
+  type: modalType;
+  title?: string;
   children: ReactNode;
-  onClickClose: () => void;
+  btnFnc: () => void;
 }
 
-function ModalFrame({ children, onClickClose }: Props) {
-  const { isOpen } = useModal();
+function ModalFrame({ height, type, title, children, btnFnc }: Props) {
+  const modal = useStore((state) => state.modals);
+  const clearModal = useStore((state) => state.clearModal);
+  const hideModal = useStore((state) => state.hideModal);
 
   useNotScroll();
 
-  if(!isOpen) {
+  if (!modal.length) {
     return null;
   }
 
   return (
-    <>
-      <ModalPortal>
-        <Mask onClick={onClickClose} />
-        <Body>
-          <CloseBtn alt="모달 닫기 버튼" onClick={onClickClose} />
-          <Container>{children}</Container>
-        </Body>
-      </ModalPortal>
-    </>
+    <ModalPortal>
+      <StyledMask $height={height} onClick={() => hideModal(type)} />
+      <StyledBody $height={height} $type={type}>
+        <StyledTitle>{title}</StyledTitle>
+        {type === 'card' && <StyledCloseBtn alt="모달 닫기 버튼" onClick={clearModal} />}
+        <StyledContainer>{children}</StyledContainer>
+        {type === 'card' || (
+          <StyledButtonBox>
+            {type === 'incorrectPWAlert' || (
+              <StyledButtonWrapper>
+                <Button.Plain style="outline" roundSize="L" onClick={() => hideModal(type)}>
+                  <StyledButtonText>취소</StyledButtonText>
+                </Button.Plain>
+              </StyledButtonWrapper>
+            )}
+            <StyledButtonWrapper>
+              <Button.Plain style="primary" roundSize="L" onClick={btnFnc}>
+                <StyledButtonText>
+                  {type === 'manageColumn' && '변경'}
+                  {(type === 'createColumn' || type === 'dashBoard') && '생성'}
+                  {(type === 'deleteColumnAlert' || type === 'deleteCardAlert') && '삭제'}
+                  {type === 'incorrectPWAlert' && '확인'}
+                </StyledButtonText>
+              </Button.Plain>
+            </StyledButtonWrapper>
+          </StyledButtonBox>
+        )}
+      </StyledBody>
+    </ModalPortal>
   );
 }
 
 export default ModalFrame;
 
-const Mask = styled.div`
-  width: 100%;
-  height: 100%;
-  
+const StyledMask = styled.div<{ $height: 'Low' | 'Mid' | 'High' }>`
+  width: 100vw;
+  height: 100vh;
+
   position: fixed;
   top: 0;
   left: 0;
-  z-index: ${modalFrame_Mask};
+  ${(props) => props.$height === 'Low' && `z-index: ${Z_INDEX.modalFrame_Mask_Low}`};
+  ${(props) => props.$height === 'Mid' && `z-index: ${Z_INDEX.modalFrame_Mask_Mid}`};
+  ${(props) => props.$height === 'High' && `z-index: ${Z_INDEX.modalFrame_Mask_High}`};
 
   background-color: black;
   opacity: 0.4;
 `;
 
-const Body = styled.div`
-  width: 360px;
-  
+const StyledBody = styled.div<{ $height: 'Low' | 'Mid' | 'High'; $type: modalType }>`
+  width: 540px;
+  padding: ${({ $type }) =>
+    $type === 'incorrectPWAlert' || $type === 'deleteCardAlert' || $type === 'deleteColumnAlert'
+      ? '56px 28px 32px 28px'
+      : '32px 28px'};
+
   position: fixed;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: ${modalFrame_Body};
+  ${(props) => props.$height === 'Low' && `z-index: ${Z_INDEX.modalFrame_Body_Low}`};
+  ${(props) => props.$height === 'Mid' && `z-index: ${Z_INDEX.modalFrame_Body_Mid}`};
+  ${(props) => props.$height === 'High' && `z-index: ${Z_INDEX.modalFrame_Body_High}`};
 
   border-radius: 8px;
   background: white;
 `;
 
-const CloseBtn = styled(CloseIcon)`
+const StyledTitle = styled.h1`
+  ${FONT_24_B};
+  color: ${BLACK[2]};
+`;
+
+const StyledCloseBtn = styled(CloseIcon)`
   position: absolute;
   top: 16px;
   right: 16px;
   &:hover {
     cursor: pointer;
   }
-`
+`;
 
-const Container = styled.div`
-  padding: 32px 40px;
+const StyledContainer = styled.div`
+  width: 100%;
+  padding: 32px 0;
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
   gap: 8px;
-`
+`;
+
+const StyledButtonBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 28px;
+`;
+
+const StyledButtonWrapper = styled.div`
+  width: 120px;
+  height: 48px;
+`;
+
+const StyledButtonText = styled.span`
+  ${FONT_14};
+`;

--- a/components/common/Modal/ModalFrame.tsx
+++ b/components/common/Modal/ModalFrame.tsx
@@ -83,7 +83,7 @@ const StyledBody = styled.div<{ $height: 'Low' | 'Mid' | 'High'; $type: modalTyp
   width: 540px;
   padding: ${({ $type }) =>
     $type === 'incorrectPWAlert' || $type === 'deleteCardAlert' || $type === 'deleteColumnAlert'
-      ? '56px 28px 32px 28px'
+      ? '26px 28px 32px 28px'
       : '32px 28px'};
 
   position: fixed;
@@ -114,7 +114,7 @@ const StyledCloseBtn = styled(CloseIcon)`
 
 const StyledContainer = styled.div`
   width: 100%;
-  padding: 32px 0;
+  padding: 32px 0 0;
   position: relative;
   display: flex;
   flex-direction: column;

--- a/components/common/Modal/index.ts
+++ b/components/common/Modal/index.ts
@@ -1,0 +1,5 @@
+// import ColumnModal from "./ColumnModal";
+
+// export const Modal = Object.assign( , {
+//   Column: ColumnModal,
+// });

--- a/components/common/Textarea/TextArea.tsx
+++ b/components/common/Textarea/TextArea.tsx
@@ -1,14 +1,14 @@
 import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import styled from 'styled-components';
-import Button from './Button';
-import { FONT_16 } from '@/styles/FontStyles';
-import 'react-quill/dist/quill.snow.css';
+import Button from '../Button';
+import { FONT_12, FONT_16 } from '@/styles/FontStyles';
 import { VIOLET } from '@/styles/ColorStyles';
+import 'react-quill/dist/quill.snow.css';
 
 const ReactQuill = dynamic(() => import('react-quill'), { ssr: false });
 
-function TextArea() {
+function Textarea() {
   const [value, setValue] = useState('');
   const [violet, setViolet] = useState(false);
 
@@ -20,9 +20,11 @@ function TextArea() {
     setViolet(!violet);
   };
 
+  const handleButtonClick = () => {};
+
   return (
-    <Wrapper>
-      <Label>댓글</Label>
+    <StyledWrapper>
+      <StyledLabel>댓글</StyledLabel>
       <StyledReactQuill
         theme="snow"
         value={value}
@@ -31,26 +33,18 @@ function TextArea() {
         onBlur={handleReactQuillBlur}
         $violet={violet}
       />
-      <Button
-        type="secondary"
-        fontSize="S"
-        width="83px"
-        height="32px"
-        active={true}
-        roundSize="S"
-        position="absolute"
-        right="10px"
-        bottom="10px"
-      >
-        입력
-      </Button>
-    </Wrapper>
+      <StyledButtonWrapper>
+        <Button.Plain style="secondary" roundSize="S" onClick={handleButtonClick}>
+          <StyledButtonText>입력</StyledButtonText>
+        </Button.Plain>
+      </StyledButtonWrapper>
+    </StyledWrapper>
   );
 }
 
-export default TextArea;
+export default Textarea;
 
-const Wrapper = styled.div`
+const StyledWrapper = styled.div`
   width: 450px;
   position: relative;
   display: flex;
@@ -58,7 +52,7 @@ const Wrapper = styled.div`
   gap: 10px;
 `;
 
-const Label = styled.label`
+const StyledLabel = styled.label`
   ${FONT_16}
 `;
 
@@ -81,4 +75,16 @@ const StyledReactQuill = styled(ReactQuill)<{ $violet: boolean }>`
     min-height: 110px;
     padding-bottom: 42px;
   }
+`;
+
+const StyledButtonWrapper = styled.div`
+  width: 83px;
+  height: 32px;
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+`;
+
+const StyledButtonText = styled.span`
+  ${FONT_12};
 `;

--- a/context/stores/bearSlice.ts
+++ b/context/stores/bearSlice.ts
@@ -1,8 +1,0 @@
-import { StateCreator } from 'zustand';
-import { FishSlice, BearSlice } from '@/lib/types/zustand';
-
-export const createBearSlice: StateCreator<BearSlice & FishSlice, [], [], BearSlice> = (set) => ({
-  bears: 0,
-  addBear: () => set((state) => ({ bears: state.bears + 1 })),
-  eatFish: () => set((state) => ({ fishes: state.fishes - 1 })),
-});

--- a/context/stores/fishSlice.ts
+++ b/context/stores/fishSlice.ts
@@ -1,7 +1,0 @@
-import { StateCreator } from 'zustand';
-import { FishSlice } from '@/lib/types/zustand';
-
-export const createFishSlice: StateCreator<FishSlice> = (set) => ({
-  fishes: 0,
-  addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
-});

--- a/context/stores/index.ts
+++ b/context/stores/index.ts
@@ -1,24 +1,10 @@
-import { create, StateCreator } from 'zustand';
-import { createBearSlice } from './bearSlice';
-import { createFishSlice } from './fishSlice';
-import { FishSlice, BearSlice, SharedSlice } from '@/lib/types/zustand';
+import { create } from 'zustand';
+import { createModalSlice } from './modalSlice';
+import { ModalState } from '@/lib/types/zustand';
 // 공식문서
 // SlicePattern: https://docs.pmnd.rs/zustand/guides/slices-pattern#slicing-the-store-into-smaller-stores
 // TypeScript: https://docs.pmnd.rs/zustand/guides/typescript
 
-export const createSharedSlice: StateCreator<BearSlice & FishSlice, [], [], SharedSlice> = (set, get) => ({
-  addBoth: () => {
-    // you can reuse previous methods
-    get().addBear();
-    get().addFish();
-    // or do them from scratch
-    // set((state) => ({ bears: state.bears + 1, fishes: state.fishes + 1 })
-  },
-  getBoth: () => get().bears + get().fishes,
-});
-
-export const useBoundStore = create<BearSlice & FishSlice & SharedSlice>()((...a) => ({
-  ...createBearSlice(...a),
-  ...createFishSlice(...a),
-  ...createSharedSlice(...a),
+export const useStore = create<ModalState>()((...a) => ({
+  ...createModalSlice(...a),
 }));

--- a/context/stores/modalSlice.ts
+++ b/context/stores/modalSlice.ts
@@ -1,0 +1,10 @@
+import { StateCreator } from 'zustand';
+import { ModalState } from '@/lib/types/zustand';
+
+export const createModalSlice: StateCreator<ModalState> = (set) => ({
+  modals: [],
+  showModal: (type) => set((state) => ({ ...state, modals: [...state.modals, type] })),
+  hideModal: (type) =>
+    set((state) => ({ ...state, modals: [...state.modals.filter((modalType) => modalType !== type)] })),
+  clearModal: () => set((state) => ({ ...state, modals: [] })),
+});

--- a/lib/constants/inputErrorMsg.ts
+++ b/lib/constants/inputErrorMsg.ts
@@ -12,3 +12,7 @@ export const voidTitle = '제목을 입력해주세요.';
 
 // 마감일
 export const voidDueDate = '마감일을 입력해주세요.';
+
+// 칼럼 이름
+export const overlapName = '중복된 칼럼 이름입니다.';
+export const voidName = '이름을 입력해주세요.';

--- a/lib/types/zustand.ts
+++ b/lib/types/zustand.ts
@@ -1,15 +1,15 @@
-export interface FishSlice {
-  fishes: number;
-  addFish: () => void;
-}
+export type modalType =
+  | 'createColumn'
+  | 'manageColumn'
+  | 'card'
+  | 'incorrectPWAlert'
+  | 'deleteColumnAlert'
+  | 'deleteCardAlert'
+  | 'dashBoard';
 
-export interface BearSlice {
-  bears: number;
-  addBear: () => void;
-  eatFish: () => void;
-}
-
-export interface SharedSlice {
-  addBoth: () => void;
-  getBoth: () => void;
+export interface ModalState {
+  modals: modalType[];
+  showModal: (type: modalType) => void;
+  hideModal: (type: modalType) => void;
+  clearModal: () => void;
 }

--- a/lib/utils/checkSign.ts
+++ b/lib/utils/checkSign.ts
@@ -7,6 +7,7 @@ import {
   doubleCheckPassword,
   voidTitle,
   voidDueDate,
+  voidName,
 } from '../constants/inputErrorMsg';
 
 const EMAIL_REGEX = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
@@ -63,6 +64,9 @@ export const validateEtc = (type: string, value: string) => {
   let errMsg = '';
   if (type === 'title' && value === '') {
     errMsg = voidTitle;
+    return errMsg;
+  } else if (type === 'name' && value === '') {
+    errMsg = voidName;
     return errMsg;
   }
   return errMsg;

--- a/lib/utils/getInputLabel.ts
+++ b/lib/utils/getInputLabel.ts
@@ -22,6 +22,12 @@ export const getInputLabel = (type: string) => {
     case 'nickname':
       label = '닉네임';
       break;
+    case 'name':
+      label = '이름';
+      break;
+    case 'dashboard':
+      label = '대시보드 이름';
+      break;
     default:
       label = '';
       break;

--- a/lib/utils/getPlaceholder.ts
+++ b/lib/utils/getPlaceholder.ts
@@ -22,6 +22,12 @@ export const getPlaceholder = (type: string) => {
     case 'nickname':
       placeholder = '닉네임을 입력해 주세요';
       break;
+    case 'name':
+      placeholder = '이름을 입력해 주세요';
+      break;
+    case 'dashboard':
+      placeholder = '대시보드 이름을 입력해 주세요';
+      break;
     default:
       placeholder = '';
       break;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ export default function App({ Component, pageProps }: AppProps) {
       </Head>
       <GlobalStyles />
       <Component {...pageProps} />
+      <div id="modal"></div>
     </>
   );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -29,7 +29,6 @@ export default class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
-          <div id='modal'></div>
         </body>
       </Html>
     );

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -1,27 +1,39 @@
 import styled from 'styled-components';
-import TextArea from '@/components/common/TextArea';
-import ButtonBase from '@/components/common/Button/ButtonBase';
-import { FONT_15, FONT_24 } from '@/styles/FontStyles';
-import Button from '@/components/common/Button';
+import ColumnModal from '@/components/common/Modal/ColumnModal';
+import { useStore } from '@/context/stores';
+import { modalType } from '@/lib/types/zustand';
 
 /**
  * 컴포넌트 실험용 페이지입니다. (컴포넌트 구현 완료 후 삭제 예정)
  */
 
 export default function Test() {
+  const modal = useStore((state) => state.modals);
+  const showModal = useStore((state) => state.showModal);
+
+  const handleButtonClick = (type: modalType) => {
+    if (modal.includes(type)) return;
+    showModal(type);
+  };
+
   return (
-    <>
-      <Button.Add roundSize="L">냐냐</Button.Add>
-      <Button.Arrow type="left" isNotActive></Button.Arrow>
-      <Button.Arrow type="right"></Button.Arrow>
-      <Button.Plain style="primary" roundSize="L" isNotActive>
-        <Div>primary 버튼</Div>
-      </Button.Plain>
-    </>
+    <Div>
+      <Button onClick={() => handleButtonClick('dashBoard')}>새 컬럼 생성</Button>
+      <Button onClick={() => handleButtonClick('manageColumn')}>칼럼 삭제</Button>
+      {modal.length > 0 && <ColumnModal type={modal[modal.length - 1]} />}
+    </Div>
   );
 }
 
 const Div = styled.div`
-  color: white;
-  ${FONT_24};
+  margin-bottom: 30px;
+  padding: 30px;
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+`;
+
+const Button = styled.button`
+  height: 20px;
+  background-color: white;
 `;

--- a/pages/test.tsx
+++ b/pages/test.tsx
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import ColumnModal from '@/components/common/Modal/ColumnModal';
 import { useStore } from '@/context/stores';
 import { modalType } from '@/lib/types/zustand';
+import DashboardModal from '@/components/common/Modal/DashboardModal';
+import AlertModal from '@/components/common/Modal/AlertModal';
 
 /**
  * 컴포넌트 실험용 페이지입니다. (컴포넌트 구현 완료 후 삭제 예정)
@@ -18,9 +20,18 @@ export default function Test() {
 
   return (
     <Div>
-      <Button onClick={() => handleButtonClick('dashBoard')}>새 컬럼 생성</Button>
-      <Button onClick={() => handleButtonClick('manageColumn')}>칼럼 삭제</Button>
+      <Button onClick={() => handleButtonClick('dashBoard')}>새로운 대시보드</Button>
+      <Button onClick={() => handleButtonClick('manageColumn')}>칼럼 관리</Button>
+      <Button onClick={() => handleButtonClick('createColumn')}>새 칼럼 생성</Button>
+      <Button onClick={() => handleButtonClick('incorrectPWAlert')}>일치하지 않는 비밀번호</Button>
+      <Button onClick={() => handleButtonClick('deleteColumnAlert')}>칼럼 삭제</Button>
+      <Button onClick={() => handleButtonClick('deleteCardAlert')}>카드 삭제</Button>
+      {modal[modal.length - 1] === 'dashBoard' && <DashboardModal type={'dashBoard'} />}
       {modal.length > 0 && <ColumnModal type={modal[modal.length - 1]} />}
+      {modal[modal.length - 1] === 'createColumn' && <ColumnModal type={'createColumn'} />}
+      {modal[modal.length - 1] === 'incorrectPWAlert' && <AlertModal type={'incorrectPWAlert'} />}
+      {modal[modal.length - 1] === 'deleteColumnAlert' && <AlertModal type={'deleteColumnAlert'} />}
+      {modal[modal.length - 1] === 'deleteCardAlert' && <AlertModal type={'deleteCardAlert'} />}
     </Div>
   );
 }

--- a/styles/ZIndexStyles.ts
+++ b/styles/ZIndexStyles.ts
@@ -3,8 +3,12 @@
  * 컴포넌트이름+스타일컴포넌트이름
  */
 export const Z_INDEX = {
-  modalFrame_Mask: 900,
-  modalFrame_Body: 900,
+  modalFrame_Mask_Low: 700,
+  modalFrame_Body_Low: 700,
+  modalFrame_Mask_Mid: 800,
+  modalFrame_Body_Mid: 800,
+  modalFrame_Mask_High: 900,
+  modalFrame_Body_High: 900,
   profileImgList_Img: [1, 2, 3, 4],
   profileImgList_Rest: 5,
   secondHeader_Body: 100,


### PR DESCRIPTION
## 수정 내용

- Zustand를 사용한 모달 상태 관리(Zustand 코드를 잘 참고해주시기 바랍니다)
- modalFrame, modalPortal 및 모달 6종 구현
- 버튼 및 Styled-components 리팩토링

## (선택) 스크린샷

### 한 번에 한개의 모달만 오픈
https://github.com/like-tenten/tenten/assets/122101706/d3eeefb2-3165-44bf-9159-81eae56c0e64
```ts
{modal[modal.length - 1] === 'manageColumn' && <ColumnModal type={'manageColumn'} />}
{modal[modal.length - 1] === 'deleteColumnAlert' && <AlertModal type={'deleteColumnAlert'} />}
```

### 배열 스택에 모달이 쌓이는 컨셉, 닫힐 때도 pop
https://github.com/like-tenten/tenten/assets/122101706/97c5f795-44f8-4d99-8b7e-710c6c1ec7a4
```ts
{modal.length > 0 && <ColumnModal type={'manageColumn'} />}
{modal[modal.length - 1] === 'deleteColumnAlert' && <AlertModal type={'deleteColumnAlert'} />}
```

## 기타

- 위 코드로 사용법 이해 부탁드려요
- 이제 할일 생성, 수정 및 카드 모달까지 작업 계속 할게요.
- 할일 생성, 수정의 태그 input의 기능은 현재로써는 따로 구현하지 않겠습니다.
- 이미지 업로드 기능도 현재는 하지 않고, 시간될 때 기능 구현할게요.
