### PR TITLE
[이태희] /myboard 초대받은 대시보드 반응형 수정

### DIFF
--- a/components/common/Table/InviteDash.tsx
+++ b/components/common/Table/InviteDash.tsx
@@ -1,12 +1,13 @@
 import styled from 'styled-components';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
-import { GRAY } from '@/styles/ColorStyles';
+import { GRAY, WHITE } from '@/styles/ColorStyles';
 import SearchIcon from '@/public/icon/search.svg';
 import InviteList from './InviteList';
-import { Invites } from '@/lib/types/type';
+import { InvitationList } from '@/lib/types/type';
+import { FONT_16, FONT_20_B, FONT_24_B } from '@/styles/FontStyles';
 
 interface Props {
-  inviteList: Invites;
+  inviteList: InvitationList;
 }
 
 function InviteDash({ inviteList }: Props) {
@@ -15,10 +16,12 @@ function InviteDash({ inviteList }: Props) {
   return (
     <Container>
       <InviteDashTitle>초대받은 대시보드</InviteDashTitle>
-      <InviteDashInputWrap>
-        <Search />
-        <SearchInput />
-      </InviteDashInputWrap>
+      <InviteInputLayout>
+        <InviteDashInputWrap>
+          <Search />
+          <SearchInput />
+        </InviteDashInputWrap>
+      </InviteInputLayout>
       <InviteListHead>
         <Subject>이름</Subject>
         <Subject>초대자</Subject>
@@ -36,9 +39,10 @@ function InviteDash({ inviteList }: Props) {
 export default InviteDash;
 
 const Container = styled.div`
-  width: 1022px;
+  width: 950px;
   height: 600px;
   padding-top: 32px;
+  background-color: ${[WHITE]};
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     width: 504px;
@@ -48,23 +52,29 @@ const Container = styled.div`
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     width: 260px;
     height: 836px;
-    padding: 24px 16px 0;
   }
 `;
 
 const InviteDashTitle = styled.div`
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: normal;
+  ${[FONT_24_B]}
   padding: 0 28px;
-`;
 
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    ${[FONT_20_B]}
+    padding: 0 16px;
+  }
+`;
+const InviteInputLayout = styled.div`
+  margin: 20px 0 24px;
+  padding: 0 28px;
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    padding: 0 16px;
+  }
+`;
 const InviteDashInputWrap = styled.div`
   border: 1px solid ${GRAY[30]};
   border-radius: 6px;
   display: flex;
-  margin: 32px;
 `;
 
 const Search = styled(SearchIcon)`
@@ -83,24 +93,26 @@ const InviteContent = styled.div`
 
 const InviteListHead = styled.div`
   display: flex;
-  width: 870px;
   padding: 20px 32px;
   color: ${GRAY[40]};
-  :nth-child(1) {
-    flex-basis: 40%;
-    flex-grow: 1;
+
+  & > div:nth-child(1) {
+    flex-basis: 38%;
+    @media (max-width: ${DEVICE_SIZE.tablet}) {
+      flex-basis: 41%;
+    }
   }
-  :nth-child(2) {
-    flex-basis: 30%;
-    flex-grow: 1;
+  & > div:nth-child(2) {
+    flex-basis: 41%;
+    @media (max-width: ${DEVICE_SIZE.tablet}) {
+      flex-basis: 25%;
+    }
   }
-  :nth-child(3) {
-    flex-basis: 20%;
-    flex-grow: 1;
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: none;
   }
 `;
 
 const Subject = styled.div`
-  font-size: 16px;
-  font-weight: 400;
+  ${[FONT_16]};
 `;

--- a/components/common/Table/InviteList.tsx
+++ b/components/common/Table/InviteList.tsx
@@ -94,10 +94,12 @@ const InviteDashLayout = styled.div`
     margin-bottom: 10px;
 
     & > div:nth-child(1) {
-      flex-grow: 1;
+      flex-basis: 30%;
+      border: 1px solid red;
     }
     & > div:nth-child(2) {
-      flex-grow: 1;
+      flex-basis: 70%;
+      border: 1px solid blue;
     }
   }
 `;
@@ -108,10 +110,12 @@ const InviterName = styled.div`
     margin-bottom: 16px;
 
     & > div:nth-child(1) {
-      flex-grow: 1;
+      flex-basis: 30%;
+      border: 1px solid red;
     }
     & > div:nth-child(2) {
-      flex-grow: 4;
+      flex-basis: 70%;
+      border: 1px solid blue;
     }
   }
 `;

--- a/components/common/Table/InviteList.tsx
+++ b/components/common/Table/InviteList.tsx
@@ -1,26 +1,49 @@
-import { Invite as InviteType } from '@/lib/types/type';
+import { Invitation } from '@/lib/types/type';
 import { GRAY } from '@/styles/ColorStyles';
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import { FONT_16, FONT_14, FONT_12 } from '@/styles/FontStyles';
 import { styled } from 'styled-components';
+import { BLUE, GREEN, ORANGE, PINK, PURPLE } from '@/styles/ColorStyles';
 import Button from '../Button';
+
+const CHIP_COLOR = {
+  green: GREEN,
+  purple: PURPLE,
+  orange: ORANGE,
+  blue: BLUE,
+  pink: PINK[1],
+};
+
 interface Props {
-  invite: InviteType;
+  invite: Invitation;
 }
 
 function InviteList({ invite }: Props) {
   return (
     <InviteWrap>
-      <InviteItems>
-        <InviteData>{invite.dashboard.title}</InviteData>
-        <InviteData>{invite.invitee.nickname}</InviteData>
+      <InviteContainer>
+        <StyledChip $color="green" />
+        <InviteDashLayout>
+          <InviteInformation>이름</InviteInformation>
+          <InviteData>{invite.dashboard.title}</InviteData>
+        </InviteDashLayout>
+        <InviterName>
+          <InviteInformation>초대자</InviteInformation>
+          <InviteData>{invite.invitee.nickname}</InviteData>
+        </InviterName>
         <ButtonGroup>
-          <Button type="primary" width="84px" height="32px" roundSize="S">
-            수락
-          </Button>
-          <Button type="plain" width="84px" height="32px" roundSize="S">
-            거절
-          </Button>
+          <ButtonLayout>
+            <Button.Plain style="primary" roundSize="S">
+              <ButtonText>수락</ButtonText>
+            </Button.Plain>
+          </ButtonLayout>
+          <ButtonLayout>
+            <Button.Plain style="secondary" roundSize="S">
+              <ButtonText>거절</ButtonText>
+            </Button.Plain>
+          </ButtonLayout>
         </ButtonGroup>
-      </InviteItems>
+      </InviteContainer>
     </InviteWrap>
   );
 }
@@ -28,25 +51,80 @@ function InviteList({ invite }: Props) {
 export default InviteList;
 
 const InviteWrap = styled.div`
-  padding: 20px 36px;
+  padding: 20px 0px;
   border-bottom: 1px solid ${GRAY[30]};
 `;
 
-const InviteItems = styled.div`
-  width: 800px;
+const InviteContainer = styled.div`
   display: flex;
+  padding: 0px 28px;
   align-items: center;
-  :nth-child(1) {
+  & > div:nth-child(1) {
+    @media (max-width: ${DEVICE_SIZE.tablet}) {
+      flex-basis: 3%;
+    }
+    @media (max-width: ${DEVICE_SIZE.mobile}) {
+      display: none;
+    }
+  }
+  & > div:nth-child(2) {
+    flex-basis: 36%;
+
+    @media (max-width: ${DEVICE_SIZE.tablet}) {
+      flex-basis: 60%;
+    }
+  }
+  & > div:nth-child(3) {
     flex-basis: 40%;
-    flex-grow: 1;
   }
-  :nth-child(2) {
-    flex-basis: 30%;
-    flex-grow: 1;
-  }
-  :nth-child(3) {
+  & > div:nth-child(4) {
     flex-basis: 20%;
-    flex-grow: 1;
+  }
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+  }
+`;
+
+const InviteDashLayout = styled.div`
+  display: flex;
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    margin-bottom: 10px;
+
+    & > div:nth-child(1) {
+      flex-grow: 1;
+    }
+    & > div:nth-child(2) {
+      flex-grow: 1;
+    }
+  }
+`;
+
+const InviterName = styled.div`
+  display: flex;
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    margin-bottom: 16px;
+
+    & > div:nth-child(1) {
+      flex-grow: 1;
+    }
+    & > div:nth-child(2) {
+      flex-grow: 4;
+    }
+  }
+`;
+
+const StyledChip = styled.div<{ $color: 'green' | 'purple' | 'orange' | 'blue' | 'pink' }>`
+  margin-right: 16px;
+  width: 8px;
+  height: 8px;
+  background-color: ${({ $color }) => `${CHIP_COLOR[$color]}`};
+  border-radius: 100%;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    margin-right: 12px;
   }
 `;
 
@@ -56,6 +134,34 @@ const ButtonGroup = styled.div`
 `;
 
 const InviteData = styled.div`
-  font-size: 16px;
-  font-weight: 400;
+  ${[FONT_16]}
+`;
+
+const ButtonText = styled.div`
+  ${[FONT_14]}
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    ${[FONT_12]}
+  }
+`;
+
+const ButtonLayout = styled.div`
+  width: 84px;
+  height: 32px;
+
+  @media (max-width: ${DEVICE_SIZE.tablet}) {
+    width: 72px;
+    height: 30px;
+  }
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    width: 109px;
+  }
+`;
+
+const InviteInformation = styled.div`
+  display: none;
+  color: ${[GRAY[40]]};
+  ${[FONT_14]}
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: inline-block;
+  }
 `;

--- a/components/common/Table/InviteList.tsx
+++ b/components/common/Table/InviteList.tsx
@@ -85,6 +85,7 @@ const InviteContainer = styled.div`
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
+    padding: 0px 16px;
   }
 `;
 
@@ -95,11 +96,9 @@ const InviteDashLayout = styled.div`
 
     & > div:nth-child(1) {
       flex-basis: 30%;
-      border: 1px solid red;
     }
     & > div:nth-child(2) {
       flex-basis: 70%;
-      border: 1px solid blue;
     }
   }
 `;
@@ -111,11 +110,9 @@ const InviterName = styled.div`
 
     & > div:nth-child(1) {
       flex-basis: 30%;
-      border: 1px solid red;
     }
     & > div:nth-child(2) {
       flex-basis: 70%;
-      border: 1px solid blue;
     }
   }
 `;

--- a/components/common/Table/mock.json
+++ b/components/common/Table/mock.json
@@ -11,6 +11,7 @@
       },
       "invitee": {
         "nickname": "손동희",
+        "email": "AAA@naver.com",
         "id": 2
       },
       "inviteAccepted": true,
@@ -27,6 +28,7 @@
       },
       "invitee": {
         "nickname": "안귀영",
+        "email": "AAA@naver.com",
         "id": 3
       },
       "inviteAccepted": true,
@@ -34,7 +36,7 @@
       "updatedAt": "2023-12-20T04:38:51.003Z"
     },
     {
-      "id": 2,
+      "id": 3,
       "inviterUserId": 3,
       "teamId": "team-8",
       "dashboard": {
@@ -43,6 +45,7 @@
       },
       "invitee": {
         "nickname": "장혁",
+        "email": "AAA@naver.com",
         "id": 3
       },
       "inviteAccepted": true,

--- a/pages/myboard/index.tsx
+++ b/pages/myboard/index.tsx
@@ -5,6 +5,7 @@ import InviteDash from '@/components/common/Table/InviteDash';
 import DashBoardList from '@/components/pages/myboard/DashBoardList';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import dashboardData from '@/components/common/SideMenu/mock';
+import inviteList from '@/components/common/Table/mock.json';
 
 const inviteData = {
   cursorId: 123,
@@ -70,7 +71,7 @@ function Myboard() {
       <StyledBody>
         <StyledContainer>
           <DashBoardList data={data} />
-          <InviteDash inviteList={inviteData} />
+          <InviteDash inviteList={inviteList} />
         </StyledContainer>
       </StyledBody>
     </>


### PR DESCRIPTION
## 수정 내용
- /myboard 초대받은 대시보드 수정했습니다.

## (선택) 스크린샷
PC
<img width="751" alt="초대받은내역리스트(pc)" src="https://github.com/like-tenten/tenten/assets/69644470/79a91aa8-62b8-4368-9d90-ef6a061420b0">
Tablet
<img width="392" alt="초대받은 내역리스트 (tablet)" src="https://github.com/like-tenten/tenten/assets/69644470/064e6ba3-2d09-4bca-bc28-263e377515da">
mobile
<img width="198" alt="초대받은내역리스트(mobile)" src="https://github.com/like-tenten/tenten/assets/69644470/aac75022-ec02-42ed-ad56-09c030eae296">

## 기타

