### PR TITLE
[안유진] 태그 색상을 위한 MongoDB 연결 & REST API 제공

### DIFF
--- a/components/common/Card/CardList.tsx
+++ b/components/common/Card/CardList.tsx
@@ -105,7 +105,7 @@ const StyledSettingButton = styled.button`
   cursor: pointer;
 `;
 
-const StyledBtnWrapper = styled.button`
+const StyledBtnWrapper = styled.div`
   width: 100%;
   max-width: 314px;
   height: 40px;

--- a/lib/db/dbConnect.ts
+++ b/lib/db/dbConnect.ts
@@ -1,0 +1,41 @@
+import mongoose from 'mongoose';
+
+declare global {
+  var mongoose: any;
+}
+
+const MONGODB_URI = process.env.MONGODB_URI!;
+
+if (!MONGODB_URI) {
+  throw new Error('Please define the MONGODB_URI environment variable inside .env.local');
+}
+
+let cached = global.mongoose;
+
+if (!cached) {
+  cached = global.mongoose = { conn: null, promise: null };
+}
+
+async function dbConnect() {
+  if (cached.conn) {
+    return cached.conn;
+  }
+  if (!cached.promise) {
+    const opts = {
+      bufferCommands: false,
+    };
+    cached.promise = mongoose.connect(MONGODB_URI, opts).then((mongoose) => {
+      return mongoose;
+    });
+  }
+  try {
+    cached.conn = await cached.promise;
+  } catch (e) {
+    cached.promise = null;
+    throw e;
+  }
+
+  return cached.conn;
+}
+
+export default dbConnect;

--- a/lib/db/models/TagColor.ts
+++ b/lib/db/models/TagColor.ts
@@ -1,0 +1,10 @@
+import mongoose from 'mongoose';
+
+const tagColorSchema = new mongoose.Schema({
+  tagName: { type: String, default: '' },
+  colorID: { type: Number, default: 0 },
+});
+
+const TagColor = mongoose.models['TagColor'] || mongoose.model('TagColor', tagColorSchema);
+
+export default TagColor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "babel-plugin-styled-components": "^2.1.4",
         "date-fns": "^3.0.1",
         "dotenv": "^16.3.1",
+        "mongoose": "^8.0.3",
         "next": "14.0.4",
         "react": "^18",
         "react-datepicker": "^4.25.0",
@@ -2220,6 +2221,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
+      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.0.4",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.0.4.tgz",
@@ -2738,7 +2747,6 @@
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2822,6 +2830,20 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.4.tgz",
       "integrity": "sha512-36ZrGJ8fgtBr6nwNnuJ9jXIj+bn/pF6UoqmrQT7+Y99+tFFeHHsoR54+194dHdyhPjgbeoNz3Qru0oRt0l6ASQ=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "6.14.0",
@@ -3344,6 +3366,14 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
+      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/bundle-name": {
@@ -5636,6 +5666,14 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
+      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5760,6 +5798,11 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -5838,6 +5881,105 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
+      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.2.0",
+        "mongodb-connection-string-url": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.0.3.tgz",
+      "integrity": "sha512-LJRT0yP4TW14HT4r2RkxqyvoTylMSzWpl5QOeVHTnRggCLQSpkoBdgbUtORFq/mSL2o9cLCPJz+6uzFj25qbHw==",
+      "dependencies": {
+        "bson": "^6.2.0",
+        "kareem": "2.5.1",
+        "mongodb": "6.2.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "16.0.1"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -6368,7 +6510,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6983,6 +7124,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
+      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -7014,6 +7160,14 @@
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/streamsearch": {
@@ -7317,6 +7471,17 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
@@ -7466,8 +7631,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -7582,6 +7746,26 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-plugin-styled-components": "^2.1.4",
     "date-fns": "^3.0.1",
     "dotenv": "^16.3.1",
+    "mongoose": "^8.0.3",
     "next": "14.0.4",
     "react": "^18",
     "react-datepicker": "^4.25.0",

--- a/pages/api/tag/index.ts
+++ b/pages/api/tag/index.ts
@@ -1,0 +1,63 @@
+import mongoose from 'mongoose';
+import dbConnect from '@/lib/db/dbConnect';
+import { NextApiRequest, NextApiResponse } from 'next';
+import TagColor from '@/lib/db/models/TagColor';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  await dbConnect();
+  // console.log(mongoose.connection.readyState);
+
+  const { tagName, colorID } = req.query;
+
+  if (req.method === 'GET' && !tagName) {
+    const allTags = await TagColor.find({});
+    res.status(200).send(allTags);
+    return;
+  }
+
+  if (!tagName) {
+    res.status(400).send('tagName is required');
+    return;
+  }
+
+  if (req.method === 'GET') {
+    const tag = await TagColor.findOne({ tagName: tagName });
+    res.status(200).send(tag);
+    return;
+  }
+
+  if (req.method === 'POST') {
+    if (!colorID) {
+      res.status(400).send('colorID is required');
+      return;
+    }
+
+    const existingTag = await TagColor.find({ tagName: tagName });
+    if (existingTag) {
+      res.status(200).send(existingTag);
+      return;
+    }
+
+    const newTagColor = await TagColor.create({ tagName: tagName, colorID: colorID });
+    res.status(201).send(newTagColor);
+    return;
+  }
+
+  // if (req.method === 'PATCH') {
+  //   const tagColor = await TagColor.findOneAndUpdate({ tagName: tagName }, req.body, {
+  //     new: true,
+  //   });
+  //   res.status(200).send(tagColor);
+  //   return;
+  // }
+
+  // if (req.method === 'DELETE') {
+  //   const tagColor = await TagColor.findOneAndDelete({ tagName: tagName });
+  //   res.status(204).send(`"${tagName}" was deleted`);
+  //   return;
+  // }
+
+  res.status(404).send('Invalid Access');
+}
+
+export default handler;

--- a/request.http
+++ b/request.http
@@ -1,0 +1,25 @@
+### 새 태그 생성 후 리턴  (이미 존재하는 태그일 경우, 해당 태그 리턴)
+POST http://localhost:3000/api/tag?tagName=프론트엔드&colorID=2
+
+### 전체 태그 목록 조회
+GET http://localhost:3000/api/tag
+
+
+### 특정 태그 조회
+GET http://localhost:3000/api/tag?tagName=백엔드
+
+
+
+
+### 태그 삭제 (사용 예정 없음)
+DELETE http://localhost:3000/api/tag?tagName=백엔드
+
+
+### 태그 수정 (사용 예정 없음)
+PATCH http://localhost:3000/api/tag?tagName=백엔드
+Content-Type: application/json
+
+{
+  "tagName": "백엔드2",
+  "colorID": "2",
+}

--- a/styles/TagColorStyles.ts
+++ b/styles/TagColorStyles.ts
@@ -1,0 +1,29 @@
+/**
+ * 0: Default(Gray)
+ * 1: Orange
+ * 2: Green
+ * 3: Pink
+ * 4: Blue
+ */
+export const TAG_FONT_COLOR = {
+  0: '#171717',
+  1: '#D58D49',
+  2: '#86D549',
+  3: '#D549B6',
+  4: '#4981D5',
+};
+
+/**
+ * 0: Default(Gray)
+ * 1: Orange
+ * 2: Green
+ * 3: Pink
+ * 4: Blue
+ */
+export const TAG_BACKGROUND_COLOR = {
+  0: '#D9D9D9',
+  1: '#F9EEE3',
+  2: '#E7F7DB',
+  3: '#F7DBF0',
+  4: '#DBE6F7',
+};


### PR DESCRIPTION
## 수정 내용

- **몽고디비 연결**
- **REST API로 제공**
- **tag color는 ID로 관리합니다!**

## 스크린샷
**1. tag color 관련 REST API 유사 스웨거** 
(/request.http)
<img width="583" alt="image" src="https://github.com/like-tenten/tenten/assets/70089733/14695ff8-7d24-4cbe-8630-dc2a0e466e82">

**2. tag color 차트**
(/public/styles/TagColorStyles.ts)
<img width="353" alt="image" src="https://github.com/like-tenten/tenten/assets/70089733/11c9d818-3498-454b-94aa-a5224f708157">


## 기타
현재는 태그에 사용할 수 있는 컬러가 4개로 한정적인데, 
사용자 지정 색상 등 더 자유로운 색상 사용을 허용하기 위한 방법을 같이 고민해봐도 좋을것같아요!