### PR TITLE
[안희원] /myboard 대시보드 생성 기능 & 페이지네이션

### DIFF
--- a/api/dashboards/createDashboard.ts
+++ b/api/dashboards/createDashboard.ts
@@ -1,10 +1,10 @@
+import instance from '@/lib/axios';
 import { PostDashboardRequestType } from '@/lib/types/dashboards';
-import axios from 'axios';
 
 /**
  * 대시보드 생성
  */
-export const createComment = async (data: PostDashboardRequestType) => {
-  const response = await axios.post('/api/dashboards', data);
+export const createDashboard = async (data: PostDashboardRequestType) => {
+  const response = await instance.post('/api/dashboards', data);
   return response.data;
 };

--- a/api/dashboards/getDashboardInfo.ts
+++ b/api/dashboards/getDashboardInfo.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 /**
  * 대시보드 상세 조회
  */
-export const getCard = async (dashboardId: number) => {
+export const getDashboardInfo = async (dashboardId: number) => {
   const response = await axios.get(`/api/dashboards/${dashboardId}`);
   console.log(response);
   return response.data;

--- a/api/dashboards/getDashboardList.ts
+++ b/api/dashboards/getDashboardList.ts
@@ -15,6 +15,6 @@ export const getDashboardList = async (
 ) => {
   const query = navigationMethod === 'infiniteScroll' ? `cursorId=${cursorId}` : `page=${page}`;
   const response = await instance.get(`/api/dashboards?navigationMethod=${navigationMethod}&${query}&size=${size}`);
-  console.log(response);
+
   return response.data;
 };

--- a/api/dashboards/getDashboardList.ts
+++ b/api/dashboards/getDashboardList.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import instance from '@/lib/axios';
 
 /**
  * 대시보드 목록 조회
@@ -7,14 +7,14 @@ import axios from 'axios';
  * @param cursorId 무한 스크롤 선택 시 사용
  * @param page 페이지네이션 선택 시 사용
  */
-export const getCardList = async (
+export const getDashboardList = async (
   navigationMethod: 'infiniteScroll' | 'pagination',
   size: number,
   cursorId?: number,
   page?: number,
 ) => {
   const query = navigationMethod === 'infiniteScroll' ? `cursorId=${cursorId}` : `page=${page}`;
-  const response = await axios.get(`/api/dashboards?navigationMethod=${navigationMethod}&${query}&size=${size}`);
+  const response = await instance.get(`/api/dashboards?navigationMethod=${navigationMethod}&${query}&size=${size}`);
   console.log(response);
   return response.data;
 };

--- a/components/common/Button/AddButton/AddButton.tsx
+++ b/components/common/Button/AddButton/AddButton.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 import ButtonBase, { BaseProps } from '../ButtonBase';
 import AddChip from '@/components/common/Chip/AddChip';
 
-export function AddButton({ roundSize, children }: BaseProps) {
+export function AddButton({ roundSize, children, onClick }: BaseProps) {
   return (
-    <ButtonBase style="outline" roundSize={roundSize}>
+    <ButtonBase style="outline" roundSize={roundSize} onClick={onClick}>
       <StyledLayout>
         {children}
         <AddChip />

--- a/components/common/Button/ArrowButton/ArrowButton.tsx
+++ b/components/common/Button/ArrowButton/ArrowButton.tsx
@@ -8,11 +8,12 @@ import BackwordIcon from '@/public/icon/arrow_backward.svg';
 interface Props {
   type: 'left' | 'right';
   isNotActive?: boolean;
+  onClick?: () => void;
 }
 
-export function ArrowButton({ type, isNotActive = false }: Props) {
+export function ArrowButton({ type, isNotActive = false, onClick }: Props) {
   return (
-    <StyledArrowButton $type={type} $isNotActive={isNotActive}>
+    <StyledArrowButton $type={type} $isNotActive={isNotActive} onClick={onClick}>
       {type === 'left' ? <BackwordIcon /> : <ForwordIcon />}
     </StyledArrowButton>
   );

--- a/components/common/Button/DashBoardButton/DashBoardButton.tsx
+++ b/components/common/Button/DashBoardButton/DashBoardButton.tsx
@@ -5,17 +5,9 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import ForwordIcon from '@/public/icon/arrow_forward.svg';
 import Crown from '@/public/icon/crown.svg';
 
-const CHIP_COLOR = {
-  green: GREEN,
-  purple: PURPLE,
-  orange: ORANGE,
-  blue: BLUE,
-  pink: PINK[1],
-};
-
 interface Props extends BaseProps {
   isOwner?: boolean;
-  chipColor: 'green' | 'purple' | 'orange' | 'blue' | 'pink';
+  chipColor: string;
 }
 
 export function DashBoardButton({ isOwner = false, chipColor, roundSize, children, onClick }: Props) {
@@ -40,13 +32,13 @@ const StyledLayout = styled.div`
   position: relative;
 `;
 
-const StyledChip = styled.div<{ $color: 'green' | 'purple' | 'orange' | 'blue' | 'pink' }>`
+const StyledChip = styled.div<{ $color: string }>`
   margin-right: 16px;
 
   width: 8px;
   height: 8px;
 
-  background-color: ${({ $color }) => `${CHIP_COLOR[$color]}`};
+  background-color: ${({ $color }) => `${$color}`};
   border-radius: 100%;
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {

--- a/components/common/Button/DashBoardButton/DashBoardButton.tsx
+++ b/components/common/Button/DashBoardButton/DashBoardButton.tsx
@@ -18,9 +18,9 @@ interface Props extends BaseProps {
   chipColor: 'green' | 'purple' | 'orange' | 'blue' | 'pink';
 }
 
-export function DashBoardButton({ isOwner = false, chipColor, roundSize, children }: Props) {
+export function DashBoardButton({ isOwner = false, chipColor, roundSize, children, onClick }: Props) {
   return (
-    <ButtonBase style="outline" roundSize={roundSize}>
+    <ButtonBase style="outline" roundSize={roundSize} onClick={onClick}>
       <StyledLayout>
         <StyledChip $color={chipColor} />
         {children}

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -1,10 +1,14 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { modalType } from '@/lib/types/zustand';
 import Input from '../Input/Input';
 import ModalFrame from './ModalFrame';
 import { GREEN, PURPLE, ORANGE, BLUE, PINK } from '@/styles/ColorStyles';
 import DashBoardColor from '../Chip/DashBoardColor';
+import { FieldValues, useForm } from 'react-hook-form';
+import { createDashboard } from '@/api/dashboards/createDashboard';
+import { useRouter } from 'next/navigation';
+import { useStore } from '@/context/stores';
 
 interface Props {
   type: modalType;
@@ -14,15 +18,33 @@ function DashboardModal({ type }: Props) {
   const colors = [GREEN, PURPLE, ORANGE, BLUE, PINK[1]];
   const initialColor = colors[0];
   const [color, setColor] = useState(initialColor);
-  const handleButtonClick = () => {};
+  const { hideModal } = useStore((state) => ({ hideModal: state.hideModal }));
+  const { register, handleSubmit } = useForm();
+  const { push } = useRouter();
+
+  const addNewDashboard = async (data: FieldValues) => {
+    const body = { title: data.newDashboard, color };
+    const response = await createDashboard(body);
+    hideModal('dashBoard');
+    push(`/board/${response.id}`);
+  };
 
   return (
-    <ModalFrame type={type} title={'새로운 대시보드'} height="Low" btnFnc={handleButtonClick}>
-      <Input type="dashboard" />
-      <StyledColorWrapper>
-        <DashBoardColor selectedColor={color} setSelectedColor={setColor} />
-      </StyledColorWrapper>
-    </ModalFrame>
+    <>
+      <ModalFrame
+        type={type}
+        title={'새로운 대시보드'}
+        height="Low"
+        btnFnc={handleSubmit((data) => addNewDashboard(data))}
+      >
+        <form onSubmit={handleSubmit((data) => addNewDashboard(data))}>
+          <Input type="dashboard" register={register('newDashboard')} />
+          <StyledColorWrapper>
+            <DashBoardColor selectedColor={color} setSelectedColor={setColor} />
+          </StyledColorWrapper>
+        </form>
+      </ModalFrame>
+    </>
   );
 }
 

--- a/components/common/Modal/ModalFrame.tsx
+++ b/components/common/Modal/ModalFrame.tsx
@@ -16,7 +16,7 @@ interface Props {
   type: modalType;
   title?: string;
   children: ReactNode;
-  btnFnc: () => void;
+  btnFnc?: () => void;
 }
 
 function ModalFrame({ height, type, title, children, btnFnc }: Props) {

--- a/components/pages/myboard/DashBoardList.tsx
+++ b/components/pages/myboard/DashBoardList.tsx
@@ -14,7 +14,14 @@ interface Props {
  * @param data dashboard 목록의 배열
  */
 function DashBoardList({ data }: Props) {
-  const { modals, showModal } = useStore((state) => ({ modals: state.modals, showModal: state.showModal }));
+  const { modals, showModal, page, total, increasePage, decreasePage } = useStore((state) => ({
+    modals: state.modals,
+    showModal: state.showModal,
+    page: state.myboardPageNumber,
+    total: state.myboardTotalPage,
+    increasePage: state.increasePage,
+    decreasePage: state.decreasePage,
+  }));
 
   function handleDashboardAdd() {
     showModal('dashBoard');
@@ -39,10 +46,12 @@ function DashBoardList({ data }: Props) {
           </StyledButtonWrapper>
         </StyledBoardList>
         <StyledPagination>
-          <StyledPageInfo>1 페이지 중 1</StyledPageInfo>
+          <StyledPageInfo>
+            {total} 페이지 중 {page}
+          </StyledPageInfo>
           <StyledMoveButtonWrapper>
-            <Button.Arrow type="left" />
-            <Button.Arrow type="right" />
+            <Button.Arrow type="left" isNotActive={page === 1} onClick={() => decreasePage(page)} />
+            <Button.Arrow type="right" isNotActive={page === total} onClick={() => increasePage(page)} />
           </StyledMoveButtonWrapper>
         </StyledPagination>
       </StyledLayout>

--- a/components/pages/myboard/DashBoardList.tsx
+++ b/components/pages/myboard/DashBoardList.tsx
@@ -3,39 +3,51 @@ import Button from '@/components/common/Button';
 import { FONT_14, FONT_14_B, FONT_16_B } from '@/styles/FontStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { BLACK } from '@/styles/ColorStyles';
+import { DashboardType } from '@/lib/types/dashboards';
+import { useStore } from '@/context/stores';
+import DashboardModal from '@/components/common/Modal/DashboardModal';
 
 interface Props {
-  data: any;
+  data: DashboardType[];
 }
 /**
  * @param data dashboard 목록의 배열
  */
 function DashBoardList({ data }: Props) {
+  const { modals, showModal } = useStore((state) => ({ modals: state.modals, showModal: state.showModal }));
+
+  function handleDashboardAdd() {
+    showModal('dashBoard');
+  }
+
   return (
-    <StyledLayout>
-      <StyledBoardList>
-        {data &&
-          data.map((dashboard) => (
-            <StyledButtonWrapper key={dashboard.id}>
-              <Button.DashBoard isOwner={dashboard.createdByMe} chipColor="pink" roundSize="L">
-                <StyledButtonText>{dashboard.title}</StyledButtonText>
-              </Button.DashBoard>
-            </StyledButtonWrapper>
-          ))}
-        <StyledButtonWrapper>
-          <Button.Add roundSize="L">
-            <StyledButtonText>새로운 대시보드</StyledButtonText>
-          </Button.Add>
-        </StyledButtonWrapper>
-      </StyledBoardList>
-      <StyledPagination>
-        <StyledPageInfo>1 페이지 중 1</StyledPageInfo>
-        <StyledMoveButtonWrapper>
-          <Button.Arrow type="left" />
-          <Button.Arrow type="right" />
-        </StyledMoveButtonWrapper>
-      </StyledPagination>
-    </StyledLayout>
+    <>
+      <StyledLayout>
+        <StyledBoardList>
+          {data &&
+            data.map((dashboard) => (
+              <StyledButtonWrapper key={dashboard.id}>
+                <Button.DashBoard isOwner={dashboard.createdByMe} chipColor="pink" roundSize="L">
+                  <StyledButtonText>{dashboard.title}</StyledButtonText>
+                </Button.DashBoard>
+              </StyledButtonWrapper>
+            ))}
+          <StyledButtonWrapper>
+            <Button.Add roundSize="L" onClick={handleDashboardAdd}>
+              <StyledButtonText>새로운 대시보드</StyledButtonText>
+            </Button.Add>
+          </StyledButtonWrapper>
+        </StyledBoardList>
+        <StyledPagination>
+          <StyledPageInfo>1 페이지 중 1</StyledPageInfo>
+          <StyledMoveButtonWrapper>
+            <Button.Arrow type="left" />
+            <Button.Arrow type="right" />
+          </StyledMoveButtonWrapper>
+        </StyledPagination>
+      </StyledLayout>
+      {modals.length > 0 && <DashboardModal type="dashBoard" />}
+    </>
   );
 }
 

--- a/components/pages/myboard/DashBoardList.tsx
+++ b/components/pages/myboard/DashBoardList.tsx
@@ -6,6 +6,7 @@ import { BLACK } from '@/styles/ColorStyles';
 import { DashboardType } from '@/lib/types/dashboards';
 import { useStore } from '@/context/stores';
 import DashboardModal from '@/components/common/Modal/DashboardModal';
+import Link from 'next/link';
 
 interface Props {
   data: DashboardType[];
@@ -33,11 +34,13 @@ function DashBoardList({ data }: Props) {
         <StyledBoardList>
           {data &&
             data.map((dashboard) => (
-              <StyledButtonWrapper key={dashboard.id}>
-                <Button.DashBoard isOwner={dashboard.createdByMe} chipColor="pink" roundSize="L">
-                  <StyledButtonText>{dashboard.title}</StyledButtonText>
-                </Button.DashBoard>
-              </StyledButtonWrapper>
+              <Link href={`/board/${dashboard.id}`} key={dashboard.id}>
+                <StyledButtonWrapper>
+                  <Button.DashBoard isOwner={dashboard.createdByMe} chipColor="pink" roundSize="L">
+                    <StyledButtonText>{dashboard.title}</StyledButtonText>
+                  </Button.DashBoard>
+                </StyledButtonWrapper>
+              </Link>
             ))}
           <StyledButtonWrapper>
             <Button.Add roundSize="L" onClick={handleDashboardAdd}>

--- a/components/pages/myboard/DashBoardList.tsx
+++ b/components/pages/myboard/DashBoardList.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import Button from '@/components/common/Button';
 import { FONT_14, FONT_14_B, FONT_16_B } from '@/styles/FontStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
-import { BLACK } from '@/styles/ColorStyles';
+import { BLACK, VIOLET } from '@/styles/ColorStyles';
 import { DashboardType } from '@/lib/types/dashboards';
 import { useStore } from '@/context/stores';
 import DashboardModal from '@/components/common/Modal/DashboardModal';
@@ -32,25 +32,26 @@ function DashBoardList({ data }: Props) {
     <>
       <StyledLayout>
         <StyledBoardList>
-          {data &&
-            data.map((dashboard) => (
-              <Link href={`/board/${dashboard.id}`} key={dashboard.id}>
-                <StyledButtonWrapper>
-                  <Button.DashBoard isOwner={dashboard.createdByMe} chipColor="pink" roundSize="L">
-                    <StyledButtonText>{dashboard.title}</StyledButtonText>
-                  </Button.DashBoard>
-                </StyledButtonWrapper>
-              </Link>
-            ))}
           <StyledButtonWrapper>
             <Button.Add roundSize="L" onClick={handleDashboardAdd}>
               <StyledButtonText>새로운 대시보드</StyledButtonText>
             </Button.Add>
           </StyledButtonWrapper>
+          {data &&
+            data.map((dashboard) => (
+              <Link href={`/board/${dashboard.id}`} key={dashboard.id}>
+                <StyledButtonWrapper>
+                  <Button.DashBoard isOwner={dashboard.createdByMe} chipColor={dashboard.color} roundSize="L">
+                    <StyledButtonText>{dashboard.title}</StyledButtonText>
+                  </Button.DashBoard>
+                </StyledButtonWrapper>
+              </Link>
+            ))}
         </StyledBoardList>
         <StyledPagination>
           <StyledPageInfo>
-            {total} 페이지 중 {page}
+            {total} 페이지 중<span style={{ paddingRight: '5px' }} />
+            <StyledHighlight>{page}</StyledHighlight>
           </StyledPageInfo>
           <StyledMoveButtonWrapper>
             <Button.Arrow type="left" isNotActive={page === 1} onClick={() => decreasePage(page)} />
@@ -128,4 +129,8 @@ const StyledButtonText = styled.div`
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     ${FONT_14_B};
   }
+`;
+
+const StyledHighlight = styled.span`
+  font-weight: 700;
 `;

--- a/context/stores/index.ts
+++ b/context/stores/index.ts
@@ -1,10 +1,14 @@
 import { create } from 'zustand';
 import { createModalSlice } from './modalSlice';
-import { ModalState } from '@/lib/types/zustand';
+import { createMyboardPageSlice } from './myboardPageSlice';
+import { ModalState, myboardPageState } from '@/lib/types/zustand';
 // 공식문서
 // SlicePattern: https://docs.pmnd.rs/zustand/guides/slices-pattern#slicing-the-store-into-smaller-stores
 // TypeScript: https://docs.pmnd.rs/zustand/guides/typescript
 
-export const useStore = create<ModalState>()((...a) => ({
+type SliceType = ModalState & myboardPageState;
+
+export const useStore = create<SliceType>()((...a) => ({
   ...createModalSlice(...a),
+  ...createMyboardPageSlice(...a),
 }));

--- a/context/stores/modalSlice.ts
+++ b/context/stores/modalSlice.ts
@@ -1,5 +1,5 @@
 import { StateCreator } from 'zustand';
-import { ModalState } from '@/lib/types/zustand';
+import { ModalState, myboardPageState } from '@/lib/types/zustand';
 
 export const createModalSlice: StateCreator<ModalState> = (set) => ({
   modals: [],

--- a/context/stores/myboardPageSlice.ts
+++ b/context/stores/myboardPageSlice.ts
@@ -1,0 +1,10 @@
+import { StateCreator } from 'zustand';
+import { myboardPageState } from '@/lib/types/zustand';
+
+export const createMyboardPageSlice: StateCreator<myboardPageState> = (set) => ({
+  myboardTotalPage: 0,
+  myboardPageNumber: 1,
+  calcTotalPage: (totalDataNum) => set((state) => ({ ...state, myboardTotalPage: totalDataNum })),
+  increasePage: (prev) => set((state) => ({ ...state, myboardPageNumber: ++prev })),
+  decreasePage: (prev) => set((state) => ({ ...state, myboardPageNumber: --prev })),
+});

--- a/lib/types/zustand.ts
+++ b/lib/types/zustand.ts
@@ -14,3 +14,11 @@ export interface ModalState {
   hideModal: (type: modalType) => void;
   clearModal: () => void;
 }
+
+export interface myboardPageState {
+  myboardTotalPage: number;
+  myboardPageNumber: number;
+  calcTotalPage: (prev: number) => void;
+  increasePage: (prev: number) => void;
+  decreasePage: (prev: number) => void;
+}

--- a/pages/myboard/index.tsx
+++ b/pages/myboard/index.tsx
@@ -4,8 +4,11 @@ import SideMenu from '@/components/common/SideMenu/SideMenu';
 import InviteDash from '@/components/common/Table/InviteDash';
 import DashBoardList from '@/components/pages/myboard/DashBoardList';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
-import dashboardData from '@/components/common/SideMenu/mock';
 import inviteList from '@/components/common/Table/mock.json';
+import { getDashboardList } from '@/api/dashboards/getDashboardList';
+import { useEffect, useState } from 'react';
+import { DashboardType } from '@/lib/types/dashboards';
+import { useStore } from '@/context/stores';
 
 const inviteData = {
   cursorId: 123,
@@ -62,16 +65,27 @@ const inviteData = {
 };
 
 function Myboard() {
-  const data = dashboardData.dashboards;
+  const { page, setTotal } = useStore((state) => ({ page: state.myboardPageNumber, setTotal: state.calcTotalPage }));
+  const [dashboardList, setDashboardList] = useState<DashboardType[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const result = await getDashboardList('pagination', 5, undefined, page);
+      setDashboardList(result.dashboards);
+      setTotal(Math.ceil(result.totalCount / 5));
+    };
+
+    fetchData();
+  }, [page]);
 
   return (
     <>
       <Header page="myboard">내 대시보드</Header>
-      <SideMenu dashboards={data} />
+      <SideMenu dashboards={dashboardList} />
       <StyledBody>
         <StyledContainer>
-          <DashBoardList data={data} />
-          <InviteDash inviteList={inviteList} />
+          <DashBoardList data={dashboardList} />
+          <InviteDash inviteList={inviteData} />
         </StyledContainer>
       </StyledBody>
     </>


### PR DESCRIPTION
## 수정 내용

- 초대받은 대시보드 영역 제외 기능 구현 완료했습니다.
- 새로운 대시보드 데이터 생성 가능합니다.
- 페이지네이션 (어쩌다보니,, 별거없이 구현완료,,) 구현 완료했습니다.

## 스크린샷
<img width="823" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/d6f7149d-402f-40ae-b811-d9a23f1366ed">


## 기타
- 사이드메뉴 데이터 연동 여부 내일 의논해보면 좋을 것 같아요! & 글씨 잘림 현상..?
