### PR TITLE
[안희원] /myboard 페이지 1차 끝 (시안 기능 구현 완료)

### DIFF
--- a/components/common/Button/ArrowButton/ArrowButton.tsx
+++ b/components/common/Button/ArrowButton/ArrowButton.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 export function ArrowButton({ type, isNotActive = false, onClick }: Props) {
   return (
-    <StyledArrowButton $type={type} $isNotActive={isNotActive} onClick={onClick}>
+    <StyledArrowButton $type={type} $isNotActive={isNotActive} onClick={onClick} disabled={isNotActive}>
       {type === 'left' ? <BackwordIcon /> : <ForwordIcon />}
     </StyledArrowButton>
   );

--- a/components/common/Button/ButtonBase.tsx
+++ b/components/common/Button/ButtonBase.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
 const ROUND_SIZE = {
+  XL: '12px',
   L: '8px',
   M: '6px',
   S: '4px',
@@ -10,7 +11,7 @@ const ROUND_SIZE = {
 
 export interface BaseProps {
   style?: 'primary' | 'secondary' | 'outline';
-  roundSize: 'L' | 'M' | 'S';
+  roundSize: 'XL' | 'L' | 'M' | 'S';
   isNotActive?: boolean;
   children?: ReactNode;
   onClick?: () => void;
@@ -79,7 +80,7 @@ export const outline = css`
 const StyledButtonBase = styled.button<{
   $style: 'primary' | 'secondary' | 'outline';
   $isNotActive: boolean;
-  $roundSize: 'L' | 'M' | 'S';
+  $roundSize: 'XL' | 'L' | 'M' | 'S';
 }>`
   width: 100%;
   height: 100%;

--- a/components/common/Button/ButtonBase.tsx
+++ b/components/common/Button/ButtonBase.tsx
@@ -14,12 +14,19 @@ export interface BaseProps {
   isNotActive?: boolean;
   children?: ReactNode;
   onClick?: () => void;
-  type?: "button" | "reset" | "submit";
+  type?: 'button' | 'reset' | 'submit';
 }
 
 function ButtonBase({ style = 'outline', roundSize, isNotActive = false, children, onClick, type }: BaseProps) {
   return (
-    <StyledButtonBase $style={style} $isNotActive={isNotActive} $roundSize={roundSize} onClick={onClick} type={type}>
+    <StyledButtonBase
+      $style={style}
+      $isNotActive={isNotActive}
+      $roundSize={roundSize}
+      onClick={onClick}
+      type={type}
+      disabled={isNotActive}
+    >
       {children}
     </StyledButtonBase>
   );

--- a/components/common/Input/Input.tsx
+++ b/components/common/Input/Input.tsx
@@ -35,11 +35,12 @@ function Input({
 
   return (
     <>
-      <StyledContainer $type={type === 'email' || type === 'password' || type === 'passwordConfirm' || type === 'nickname' ? true : false}>
-        <StyledLabel
-          $bold={type === 'dueDate' || type === 'title' || type === 'tag' ? true : false}
-          htmlFor={type}
-        >
+      <StyledContainer
+        $type={
+          type === 'email' || type === 'password' || type === 'passwordConfirm' || type === 'nickname' ? true : false
+        }
+      >
+        <StyledLabel $bold={type === 'dueDate' || type === 'title' || type === 'tag' ? true : false} htmlFor={type}>
           {label} {type === 'title' && <StyledSpan> *</StyledSpan>}
         </StyledLabel>
         {type === 'dueDate' ? (

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -1,26 +1,31 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import { modalType } from '@/lib/types/zustand';
 import Input from '../Input/Input';
 import ModalFrame from './ModalFrame';
-import { GREEN, PURPLE, ORANGE, BLUE, PINK } from '@/styles/ColorStyles';
 import DashBoardColor from '../Chip/DashBoardColor';
-import { FieldValues, useForm } from 'react-hook-form';
+import { FieldValues, useForm, useWatch } from 'react-hook-form';
 import { createDashboard } from '@/api/dashboards/createDashboard';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/context/stores';
+import { ERROR_MSG } from '@/lib/constants/inputErrorMsg';
 
 interface Props {
   type: modalType;
 }
 
 function DashboardModal({ type }: Props) {
-  const colors = [GREEN, PURPLE, ORANGE, BLUE, PINK[1]];
-  const initialColor = colors[0];
-  const [color, setColor] = useState(initialColor);
-  const { hideModal } = useStore((state) => ({ hideModal: state.hideModal }));
-  const { register, handleSubmit } = useForm();
   const { push } = useRouter();
+  const [color, setColor] = useState('');
+  const { hideModal } = useStore((state) => ({ hideModal: state.hideModal }));
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm({ mode: 'onBlur' });
+  const nameValue = watch('newDashboard');
+  const isAllSelected = nameValue && color;
 
   const addNewDashboard = async (data: FieldValues) => {
     const body = { title: data.newDashboard, color };
@@ -36,9 +41,14 @@ function DashboardModal({ type }: Props) {
         title={'새로운 대시보드'}
         height="Low"
         btnFnc={handleSubmit((data) => addNewDashboard(data))}
+        disabledBtn={!isAllSelected}
       >
         <form onSubmit={handleSubmit((data) => addNewDashboard(data))}>
-          <Input type="dashboard" register={register('newDashboard')} />
+          <Input
+            type="dashboard"
+            register={register('newDashboard', { required: ERROR_MSG.emptyDashboardName })}
+            error={errors.newDashboard}
+          />
           <StyledColorWrapper>
             <DashBoardColor selectedColor={color} setSelectedColor={setColor} />
           </StyledColorWrapper>

--- a/components/common/Modal/ModalFrame.tsx
+++ b/components/common/Modal/ModalFrame.tsx
@@ -17,9 +17,10 @@ interface Props {
   title?: string;
   children: ReactNode;
   btnFnc?: () => void;
+  disabledBtn?: boolean;
 }
 
-function ModalFrame({ height, type, title, children, btnFnc }: Props) {
+function ModalFrame({ height, type, title, children, btnFnc, disabledBtn = false }: Props) {
   const modal = useStore((state) => state.modals);
   const clearModal = useStore((state) => state.clearModal);
   const hideModal = useStore((state) => state.hideModal);
@@ -52,7 +53,7 @@ function ModalFrame({ height, type, title, children, btnFnc }: Props) {
               </StyledButtonWrapper>
             )}
             <StyledButtonWrapper>
-              <Button.Plain style="primary" roundSize="L" onClick={btnFnc}>
+              <Button.Plain style="primary" roundSize="L" onClick={btnFnc} isNotActive={disabledBtn}>
                 <StyledButtonText>
                   {type === 'manageColumn' && '변경'}
                   {(type === 'createColumn' || type === 'dashBoard') && '생성'}

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -45,7 +45,7 @@ const StyledWrapper = styled.div`
   width: 300px;
   height: 1550px;
   padding: 20px 24px;
-  /* box-shadow: rgba(0, 0, 0, 0.15) 1.95px 0 0 0; */
+  /* box-shadow: 15px 0 15px -15px ${GRAY[30]}; */ //사이드메뉴 접었다 열었다..하고싶다..
   border-right: 1px solid ${GRAY[30]};
   position: fixed;
   left: 0;

--- a/components/common/Table/InviteDash.tsx
+++ b/components/common/Table/InviteDash.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 function InviteDash({ inviteList }: Props) {
-  const { cursorId, invitations } = inviteList;
+  const { invitations } = inviteList;
   const { search, setDashboardSearch } = useStore((state) => ({
     setDashboardSearch: state.setDashboardSearch,
     search: state.dashboardSearch,
@@ -59,6 +59,7 @@ function InviteDash({ inviteList }: Props) {
         <Subject>초대자</Subject>
         <Subject>수락여부</Subject>
       </InviteListHead>
+      {!invitations.length && search && <StyledNoSearch>검색 결과가 없습니다.</StyledNoSearch>}
       <InviteContent>
         {invitations.map((list) => (
           <InviteList key={list.id} invite={list} />
@@ -72,6 +73,7 @@ export default InviteDash;
 
 const Container = styled.div`
   width: 100%;
+  min-height: 400px;
   padding: 32px 28px 0;
 
   background-color: ${[WHITE]};
@@ -118,6 +120,14 @@ const InviteDashInputWrap = styled.form`
   display: flex;
 
   position: relative;
+
+  &:focus-within {
+    box-shadow: 0px 0px 5px ${GRAY[30]};
+  }
+
+  &:hover {
+    box-shadow: 0px 0px 5px ${GRAY[30]};
+  }
 `;
 
 const InviteContent = styled.div`
@@ -138,4 +148,16 @@ const InviteListHead = styled.div`
 
 const Subject = styled.div`
   ${[FONT_16]};
+`;
+
+const StyledNoSearch = styled.div`
+  width: 100%;
+  height: 180px;
+
+  ${[FONT_16]};
+  color: ${GRAY[50]};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 `;

--- a/components/common/Table/InviteDash.tsx
+++ b/components/common/Table/InviteDash.tsx
@@ -40,22 +40,20 @@ function InviteDash({ inviteList }: Props) {
 
   return (
     <Container>
-      <InviteDashTitle> 초대받은 대시보드</InviteDashTitle>
-      <InviteInputLayout>
-        <InviteDashInputWrap onSubmit={handleSearchSubmit}>
-          <Search />
-          <SearchInput ref={inputValue} placeholder="대시보드 이름을 검색해보세요." />
-          {search && (
-            <StyledRefreshIcon
-              alt="검색 모드 취소"
-              src="/icon/close_circle.svg"
-              width={25}
-              height={25}
-              onClick={handleRefreshClick}
-            />
-          )}
-        </InviteDashInputWrap>
-      </InviteInputLayout>
+      <InviteDashTitle>초대받은 대시보드</InviteDashTitle>
+      <InviteDashInputWrap onSubmit={handleSearchSubmit}>
+        <Search />
+        <SearchInput ref={inputValue} placeholder="대시보드 이름을 검색해보세요." />
+        {search && (
+          <StyledRefreshIcon
+            alt="검색 모드 취소"
+            src="/icon/close_circle.svg"
+            width={25}
+            height={25}
+            onClick={handleRefreshClick}
+          />
+        )}
+      </InviteDashInputWrap>
       <InviteListHead>
         <Subject>이름</Subject>
         <Subject>초대자</Subject>
@@ -74,35 +72,18 @@ export default InviteDash;
 
 const Container = styled.div`
   width: 100%;
-  height: 600px;
-  padding-top: 32px;
+  padding: 32px 28px 0;
+
   background-color: ${[WHITE]};
 
-  @media (max-width: ${DEVICE_SIZE.tablet}) {
-    /* width: 504px; */
-    height: 592px;
-  }
-
-  @media (max-width: ${DEVICE_SIZE.mobile}) {
-    /* width: 260px; */
-    height: 836px;
-  }
+  border-radius: 16px;
 `;
 
 const InviteDashTitle = styled.div`
-  ${[FONT_24_B]}
-  padding: 0 28px;
+  ${[FONT_24_B]};
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     ${[FONT_20_B]}
-    padding: 0 16px;
-  }
-`;
-const InviteInputLayout = styled.div`
-  margin: 20px 0 24px;
-  padding: 0 28px;
-  @media (max-width: ${DEVICE_SIZE.mobile}) {
-    padding: 0 16px;
   }
 `;
 
@@ -130,6 +111,8 @@ const StyledRefreshIcon = styled(Image)`
 `;
 
 const InviteDashInputWrap = styled.form`
+  margin: 20px 0 4px;
+
   border: 1px solid ${GRAY[30]};
   border-radius: 6px;
   display: flex;
@@ -142,22 +125,12 @@ const InviteContent = styled.div`
 `;
 
 const InviteListHead = styled.div`
-  display: flex;
-  padding: 20px 32px;
+  padding: 20px 28px 0;
   color: ${GRAY[40]};
 
-  & > div:nth-child(1) {
-    flex-basis: 38%;
-    @media (max-width: ${DEVICE_SIZE.tablet}) {
-      flex-basis: 41%;
-    }
-  }
-  & > div:nth-child(2) {
-    flex-basis: 41%;
-    @media (max-width: ${DEVICE_SIZE.tablet}) {
-      flex-basis: 25%;
-    }
-  }
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     display: none;
   }

--- a/components/common/Table/InviteList.tsx
+++ b/components/common/Table/InviteList.tsx
@@ -2,19 +2,9 @@ import { GRAY } from '@/styles/ColorStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { FONT_16, FONT_14, FONT_12 } from '@/styles/FontStyles';
 import { styled } from 'styled-components';
-import { BLUE, GREEN, ORANGE, PINK, PURPLE } from '@/styles/ColorStyles';
 import Button from '../Button';
 import { editInvitation } from '@/api/invitations/editInvitation';
 import { InvitationType } from '@/lib/types/invitations';
-import { useEffect, useState } from 'react';
-
-const CHIP_COLOR = {
-  green: GREEN,
-  purple: PURPLE,
-  orange: ORANGE,
-  blue: BLUE,
-  pink: PINK[1],
-};
 
 const ALERT_MSG = {
   invitationAccept: '초대를 수락하였습니다.',
@@ -37,7 +27,6 @@ function InviteList({ invite }: Props) {
   return (
     <InviteWrap>
       <InviteContainer>
-        <StyledChip $color="green" />
         <InviteDashLayout>
           <InviteInformation>이름</InviteInformation>
           <InviteData>{invite.dashboard.title}</InviteData>
@@ -79,32 +68,14 @@ const InviteWrap = styled.div`
 `;
 
 const InviteContainer = styled.div`
-  display: flex;
   padding: 0px 28px;
   align-items: center;
-  & > div:nth-child(1) {
-    @media (max-width: ${DEVICE_SIZE.tablet}) {
-      flex-basis: 3%;
-    }
-    @media (max-width: ${DEVICE_SIZE.mobile}) {
-      display: none;
-    }
-  }
-  & > div:nth-child(2) {
-    flex-basis: 36%;
 
-    @media (max-width: ${DEVICE_SIZE.tablet}) {
-      flex-basis: 60%;
-    }
-  }
-  & > div:nth-child(3) {
-    flex-basis: 40%;
-  }
-  & > div:nth-child(4) {
-    flex-basis: 20%;
-  }
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
+    display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: stretch;
@@ -116,13 +87,7 @@ const InviteDashLayout = styled.div`
   display: flex;
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     margin-bottom: 10px;
-
-    & > div:nth-child(1) {
-      flex-basis: 30%;
-    }
-    & > div:nth-child(2) {
-      flex-basis: 70%;
-    }
+    gap: 28px;
   }
 `;
 
@@ -130,25 +95,7 @@ const InviterName = styled.div`
   display: flex;
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     margin-bottom: 16px;
-
-    & > div:nth-child(1) {
-      flex-basis: 30%;
-    }
-    & > div:nth-child(2) {
-      flex-basis: 70%;
-    }
-  }
-`;
-
-const StyledChip = styled.div<{ $color: 'green' | 'purple' | 'orange' | 'blue' | 'pink' }>`
-  margin-right: 16px;
-  width: 8px;
-  height: 8px;
-  background-color: ${({ $color }) => `${CHIP_COLOR[$color]}`};
-  border-radius: 100%;
-
-  @media (max-width: ${DEVICE_SIZE.tablet}) {
-    margin-right: 12px;
+    gap: 16px;
   }
 `;
 

--- a/components/common/Table/NullInviteList.tsx
+++ b/components/common/Table/NullInviteList.tsx
@@ -21,20 +21,13 @@ function NullInviteList() {
 export default NullInviteList;
 
 const Wrapper = styled.div`
-  width: 1022px;
+  width: 100%;
   height: 400px;
   padding: 32px 28px;
-  border-radius: 8px;
+  border-radius: 16px;
   background-color: ${[WHITE]};
 
-  @media (max-width: ${DEVICE_SIZE.tablet}) {
-    width: 504px;
-    height: 400px;
-  }
-
   @media (max-width: ${DEVICE_SIZE.mobile}) {
-    width: 260px;
-    height: 400px;
     padding: 24px 16px;
   }
 `;

--- a/components/pages/myboard/DashBoardList.tsx
+++ b/components/pages/myboard/DashBoardList.tsx
@@ -33,7 +33,7 @@ function DashBoardList({ data }: Props) {
       <StyledLayout>
         <StyledBoardList>
           <StyledButtonWrapper>
-            <Button.Add roundSize="L" onClick={handleDashboardAdd}>
+            <Button.Add roundSize="XL" onClick={handleDashboardAdd}>
               <StyledButtonText>새로운 대시보드</StyledButtonText>
             </Button.Add>
           </StyledButtonWrapper>
@@ -41,7 +41,7 @@ function DashBoardList({ data }: Props) {
             data.map((dashboard) => (
               <Link href={`/board/${dashboard.id}`} key={dashboard.id}>
                 <StyledButtonWrapper>
-                  <Button.DashBoard isOwner={dashboard.createdByMe} chipColor={dashboard.color} roundSize="L">
+                  <Button.DashBoard isOwner={dashboard.createdByMe} chipColor={dashboard.color} roundSize="XL">
                     <StyledButtonText>{dashboard.title}</StyledButtonText>
                   </Button.DashBoard>
                 </StyledButtonWrapper>

--- a/lib/constants/inputErrorMsg.ts
+++ b/lib/constants/inputErrorMsg.ts
@@ -4,7 +4,7 @@ export const incorrectEmail = '올바른 이메일 주소가 아닙니다.';
 
 // Password 관련
 export const voidPassword = '비밀번호를 입력해주세요.';
-export const incorrectPassword = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+export const incorrectPassword = '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.';
 export const doubleCheckPassword = '비밀번호가 일치하지 않아요.';
 
 // 제목
@@ -21,13 +21,14 @@ export const ERROR_MSG = {
   emptyEmail: '이메일을 입력해주세요.',
   emptyPassword: '비밀번호를 입력해주세요.',
   invalidEmail: '올바른 이메일 주소가 아닙니다.',
-  invalidPassword: '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.',
+  invalidPassword: '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.',
   wrongEmail: '이메일을 확인해주세요.',
   wrongPassword: '비밀번호를 확인해주세요.',
   notEqualPassword: '비밀번호가 일치하지 않아요.',
   duplicatedEmail: '이미 사용중인 이메일입니다.',
   emptyNickname: '닉네임을 입력해주세요.',
-  invalidNickname: '2자 이상 16자 이하, 영어 또는 숫자 또는 한글로 입력해 주세요.',
+  invalidNickname: '2자 이상 16자 이하, 영어 또는 숫자 또는 한글로 입력해주세요.',
   signUpSuccessAlert: '회원가입이 성공적으로 완료되었습니다.',
-  signUpFailedAlert: '회원가입에 실패했습니다. 다시 시도해 주세요.',
+  signUpFailedAlert: '회원가입에 실패했습니다. 다시 시도해주세요.',
+  emptyDashboardName: '대시보드 이름은 1글자 이상 입력해주세요.',
 };

--- a/lib/utils/getPlaceholder.ts
+++ b/lib/utils/getPlaceholder.ts
@@ -2,31 +2,31 @@ export const getPlaceholder = (type: string) => {
   let placeholder;
   switch (type) {
     case 'email':
-      placeholder = '이메일을 입력해 주세요';
+      placeholder = '이메일을 입력해주세요';
       break;
     case 'password':
-      placeholder = '비밀번호를 입력해 주세요';
+      placeholder = '비밀번호를 입력해주세요';
       break;
     case 'passwordConfirm':
-      placeholder = '비밀번호를 다시 입력해 주세요';
+      placeholder = '비밀번호를 다시 입력해주세요';
       break;
     case 'title':
-      placeholder = '제목을 입력해 주세요';
+      placeholder = '제목을 입력해주세요';
       break;
     case 'dueDate':
-      placeholder = '날짜를 선택해 주세요';
+      placeholder = '날짜를 선택해주세요';
       break;
     case 'tag':
       placeholder = '입력 후 Enter';
       break;
     case 'nickname':
-      placeholder = '닉네임을 입력해 주세요';
+      placeholder = '닉네임을 입력해주세요';
       break;
     case 'name':
-      placeholder = '이름을 입력해 주세요';
+      placeholder = '이름을 입력해주세요';
       break;
     case 'dashboard':
-      placeholder = '대시보드 이름을 입력해 주세요';
+      placeholder = '대시보드 이름을 입력해주세요';
       break;
     default:
       placeholder = '';

--- a/pages/board/[id]/edit.tsx
+++ b/pages/board/[id]/edit.tsx
@@ -48,7 +48,6 @@ const Content = styled.div`
   width: 100%;
   padding-top: 70px;
   padding-left: 300px;
-  background-color: ${[GRAY[20]]};
   display: flex;
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {

--- a/pages/myboard/index.tsx
+++ b/pages/myboard/index.tsx
@@ -10,7 +10,6 @@ import { DashboardType } from '@/lib/types/dashboards';
 import { useStore } from '@/context/stores';
 import { getInvitationList } from '@/api/invitations/getInvitationList';
 import { inviteDashboard } from '@/api/dashboards/inviteDashboard';
-import { login } from '@/api/auth/login';
 import { GetInvitationResponseType } from '@/lib/types/invitations';
 
 const inviteData = {
@@ -88,15 +87,12 @@ function Myboard() {
 
   useEffect(() => {
     const fetchInviteListData = async () => {
-      //login
-      //const lg = login({ email: 'test@codeit.com', password: '1234asdf!' });
-      //const lg = login({ email: 'spfe01032@codeit.kr', password: 'asdf1234' });
       //대시보드 초대
-      // const data = await inviteDashboard(351, { email: 'test@codeit.com' });
-      // const data1 = await inviteDashboard(350, { email: 'test@codeit.com' });
-      // const data2 = await inviteDashboard(348, { email: 'test@codeit.com' });
-      // const data3 = await inviteDashboard(347, { email: 'test@codeit.com' });
-      // const data4 = await inviteDashboard(346, { email: 'test@codeit.com' });
+      // const data = await inviteDashboard(487, { email: 'test@codeit.com' });
+      // const data1 = await inviteDashboard(486, { email: 'test@codeit.com' });
+      // const data2 = await inviteDashboard(485, { email: 'test@codeit.com' });
+      // const data3 = await inviteDashboard(484, { email: 'test@codeit.com' });
+      // const data4 = await inviteDashboard(483, { email: 'test@codeit.com' });
 
       /**TODO : 무한스크롤
        * 무한스크롤 완료되면 위에 시험 코드들 지울 예정

--- a/pages/myboard/index.tsx
+++ b/pages/myboard/index.tsx
@@ -12,60 +12,6 @@ import { getInvitationList } from '@/api/invitations/getInvitationList';
 import { inviteDashboard } from '@/api/dashboards/inviteDashboard';
 import { GetInvitationResponseType } from '@/lib/types/invitations';
 
-const inviteData = {
-  cursorId: 123,
-  invitations: [
-    {
-      id: 1,
-      inviterUserId: 2,
-      teamId: 'team-10',
-      dashboard: {
-        title: '프로덕트 디자인',
-        id: 234,
-      },
-      invitee: {
-        nickname: '손동희',
-        id: 2,
-      },
-      inviteAccepted: true,
-      createdAt: '2023-12-20T04:38:51.003Z',
-      updatedAt: '2023-12-20T04:38:51.003Z',
-    },
-    {
-      id: 2,
-      inviterUserId: 3,
-      teamId: 'team-8',
-      dashboard: {
-        title: '새로운 기획 문서',
-        id: 234,
-      },
-      invitee: {
-        nickname: '안귀영',
-        id: 3,
-      },
-      inviteAccepted: true,
-      createdAt: '2023-12-20T04:38:51.003Z',
-      updatedAt: '2023-12-20T04:38:51.003Z',
-    },
-    {
-      id: 3,
-      inviterUserId: 3,
-      teamId: 'team-8',
-      dashboard: {
-        title: '유닛A',
-        id: 234,
-      },
-      invitee: {
-        nickname: '장혁',
-        id: 3,
-      },
-      inviteAccepted: true,
-      createdAt: '2023-12-20T04:38:51.003Z',
-      updatedAt: '2023-12-20T04:38:51.003Z',
-    },
-  ],
-};
-
 function Myboard() {
   const { page, setTotal, search } = useStore((state) => ({
     page: state.myboardPageNumber,
@@ -95,7 +41,7 @@ function Myboard() {
       // const data4 = await inviteDashboard(483, { email: 'test@codeit.com' });
 
       /**TODO : 무한스크롤
-       * 무한스크롤 완료되면 위에 시험 코드들 지울 예정
+       * 초대하기 기능 완료되면 위에 시험 코드들 지울 예정
        */
       const dashboardData = await getInvitationList(10, null, search);
       setInvitationList(dashboardData);

--- a/styles/ColorStyles.ts
+++ b/styles/ColorStyles.ts
@@ -17,6 +17,7 @@ export const VIOLET = {
   1: '#5534DA',
   2: '#4826CF',
   8: '#F1EFFD',
+  9: '#F6F4FF',
 };
 
 export const PINK = {

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -1,5 +1,5 @@
 import { createGlobalStyle } from 'styled-components';
-import { GRAY } from './ColorStyles';
+import { VIOLET } from './ColorStyles';
 
 const GlobalStyles = createGlobalStyle`
   @font-face {
@@ -19,7 +19,7 @@ const GlobalStyles = createGlobalStyle`
   }
 
   html{
-    background-color: ${GRAY[10]};
+    background-color: ${VIOLET[9]};
   }
 
   html, body, div, span, h1, h2, h3, h4, h5, h6, p, 


### PR DESCRIPTION
## 수정 내용

- /myboard 페이지 시안에 나온 기본 기능 모두 구현 완료했습니다.
- *초대 내역 무한스크롤 제외
- *로고 클릭 시, /myboard 페이지로 이동 기능 제외 (얘는 뭔가 로그인 유무에 따라서 로그인 상태면 랜딩페이지로 못가게, 로그인 안하면 myboard 접근 못하게 막아보고 싶어서 놔뒀어요!)

## 스크린샷
**기본**
<img width="989" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/69852884-28c0-476f-957b-b7f39a8cb458">

**검색 기능**
<img width="722" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/95d2032c-4a8a-4d18-b7ce-b4b4474a763f">

**검색 결과 없을 때**
<img width="740" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/3f770300-7215-4b62-b18d-11fb9e3ccd2d">

**초대 내역 없을 때**
<img width="741" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/604c3929-4dde-449a-ba36-9c6f99dec1bd">


## 기타
- 에러 없는지 한번씩 다들 체크해주시면 감사하겠습니다!!!
- 추가 기능 시작하기 전에 일단 헤더부터..하고 다시 돌아오려고 먼저 pr 올릴게용 ㅎㅎ
TT-80 TT-89 TT-91