### PR TITLE
[안희원] 헤더 데이터 연결 & 버튼 기능 추가

### DIFF
--- a/api/auth/editPassword.ts
+++ b/api/auth/editPassword.ts
@@ -1,13 +1,15 @@
 import axios from 'axios';
 import { PutPasswordRequestType } from '@/lib/types/auth';
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
+import { useRouter } from 'next/navigation';
 
 /**
  * 비밀번호 변경
  */
 export const editPassword = async (data: PutPasswordRequestType) => {
+  const router = useRouter();
   try {
-    const response = await instance.put('/api/auth/password', data);
+    const response = await authInstance.put('/api/auth/password', data);
     return response.data;
   } catch (error) {
     return error.response;

--- a/api/dashboards/createDashboard.ts
+++ b/api/dashboards/createDashboard.ts
@@ -1,10 +1,10 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 import { PostDashboardRequestType } from '@/lib/types/dashboards';
 
 /**
  * 대시보드 생성
  */
 export const createDashboard = async (data: PostDashboardRequestType) => {
-  const response = await instance.post('/api/dashboards', data);
+  const response = await authInstance.post('/api/dashboards', data);
   return response.data;
 };

--- a/api/dashboards/getDashboardInfo.ts
+++ b/api/dashboards/getDashboardInfo.ts
@@ -5,6 +5,5 @@ import authInstance from '@/lib/axios';
  */
 export const getDashboardInfo = async (dashboardId: number) => {
   const response = await authInstance.get(`/api/dashboards/${dashboardId}`);
-  console.log(response);
   return response.data;
 };

--- a/api/dashboards/getDashboardInfo.ts
+++ b/api/dashboards/getDashboardInfo.ts
@@ -1,9 +1,10 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 
 /**
  * 대시보드 상세 조회
  */
 export const getDashboardInfo = async (dashboardId: number) => {
-  const response = await instance.get(`/api/dashboards/${dashboardId}`);
+  const response = await authInstance.get(`/api/dashboards/${dashboardId}`);
+  console.log(response);
   return response.data;
 };

--- a/api/dashboards/getDashboardList.ts
+++ b/api/dashboards/getDashboardList.ts
@@ -16,7 +16,7 @@ export const getDashboardList = async (
   let query = '';
   if (cursorId) query += `cursorId=${cursorId}`;
   if (page) query += `page=${page}`;
-  const response = await instance.get(`/api/dashboards?navigationMethod=${navigationMethod}&size=${size}&${query}`);
+  const response = await authInstance.get(`/api/dashboards?navigationMethod=${navigationMethod}&size=${size}&${query}`);
 
   return response.data;
 };

--- a/api/dashboards/getDashboardList.ts
+++ b/api/dashboards/getDashboardList.ts
@@ -1,4 +1,4 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 
 /**
  * 대시보드 목록 조회

--- a/api/dashboards/inviteDashboard.ts
+++ b/api/dashboards/inviteDashboard.ts
@@ -1,4 +1,4 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 import { PostDashboardInvitationRequestType } from '@/lib/types/dashboards';
 
 /**
@@ -6,7 +6,7 @@ import { PostDashboardInvitationRequestType } from '@/lib/types/dashboards';
  */
 export const inviteDashboard = async (dashboardId: number, data: PostDashboardInvitationRequestType) => {
   try {
-    const response = await instance.post(`/api/dashboards/${dashboardId}/invitations`, data);
+    const response = await authInstance.post(`/api/dashboards/${dashboardId}/invitations`, data);
     alert('초대 성공 ><!');
     return response.data;
   } catch (error: any) {

--- a/api/dashboards/inviteDashboard.ts
+++ b/api/dashboards/inviteDashboard.ts
@@ -7,11 +7,9 @@ import { PostDashboardInvitationRequestType } from '@/lib/types/dashboards';
 export const inviteDashboard = async (dashboardId: number, data: PostDashboardInvitationRequestType) => {
   try {
     const response = await authInstance.post(`/api/dashboards/${dashboardId}/invitations`, data);
-    alert('초대 성공 ><!');
-    return response.data;
+    alert('초대에 성공했어요!');
+    return response;
   } catch (error: any) {
-    const errorMsg = error.response.data.message;
-    console.log(errorMsg);
-    return errorMsg;
+    return error.response;
   }
 };

--- a/api/invitations/editInvitation.ts
+++ b/api/invitations/editInvitation.ts
@@ -1,11 +1,11 @@
 import { PutInvitationRequestType } from '@/lib/types/invitations';
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 
 /**
  * 초대 응답
  */
 export const editInvitation = async (invitationId: string, data: PutInvitationRequestType) => {
-  const response = await instance.put(`/api/invitations/${invitationId}`, data);
+  const response = await authInstance.put(`/api/invitations/${invitationId}`, data);
   console.log(response);
   return response.data;
 };

--- a/api/invitations/getInvitationList.ts
+++ b/api/invitations/getInvitationList.ts
@@ -1,4 +1,4 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 
 /**
  * 내가 받은 초대 목록 조회
@@ -11,7 +11,7 @@ export const getInvitationList = async (size: number, cursorId: number | null, t
   path += cursorId ? `&cursorId=${cursorId}` : '';
   path += title ? `&title=${title}` : '';
 
-  const response = await instance.get(path);
+  const response = await authInstance.get(path);
 
   return response.data;
 };

--- a/api/users/editUserInfo.ts
+++ b/api/users/editUserInfo.ts
@@ -1,4 +1,4 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 import { PutDashboardRequestType } from '@/lib/types/users';
 
 /**
@@ -6,7 +6,7 @@ import { PutDashboardRequestType } from '@/lib/types/users';
  */
 export const editUserInfo = async (data: PutDashboardRequestType) => {
   try {
-    const response = await instance.put(`/api/users/me`, data);
+    const response = await authInstance.put(`/api/users/me`, data);
     return response.data;
   } catch (error) {
     return error.response;

--- a/api/users/getUserInfo.ts
+++ b/api/users/getUserInfo.ts
@@ -1,9 +1,9 @@
-import instance from '@/lib/axios';
+import authInstance from '@/lib/axios';
 
 /**
  * 내 정보 조회
  */
 export const getUserInfo = async () => {
-  const response = await instance.get(`/api/users/me`);
+  const response = await authInstance.get(`/api/users/me`);
   return response.data;
 };

--- a/components/common/Header/SecondHeader/SecondHeader.tsx
+++ b/components/common/Header/SecondHeader/SecondHeader.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { BLACK, GRAY, WHITE } from '@/styles/ColorStyles';
 import { FONT_14, FONT_16, FONT_20_B } from '@/styles/FontStyles';
 import Button from '@/components/common/Button';
@@ -12,14 +12,34 @@ import { Z_INDEX } from '@/styles/ZIndexStyles';
 import Setting from '@/public/icon/settings.svg';
 import Invite from '@/public/icon/add_box.svg';
 import Crown from '@/public/icon/crown.svg';
+import { useStore } from '@/context/stores';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '@/api/users/getUserInfo';
+import { UserType } from '@/lib/types/users';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 interface Props {
   page: 'myboard' | 'others';
   children: ReactNode;
   crown?: boolean;
+  membersData?: any;
 }
 
-function Header({ page, children, crown }: Props) {
+function Header({ page, children, crown, membersData }: Props) {
+  const [user, setUser] = useState<UserType>();
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      const response = await getUserInfo();
+      setUser(response);
+    };
+
+    fetchUser();
+  }, []);
+
+  console.log(membersData);
+
   return (
     <StyledBody>
       <StyledContainer $page={page}>
@@ -30,12 +50,12 @@ function Header({ page, children, crown }: Props) {
         <StyledRight>
           {page !== 'myboard' && (
             <>
-              <HeaderButtons />
+              <HeaderButtons createdByMe={crown} />
               <ProfileImgList memberCount={MEMBERS1.totalCount} data={MEMBERS1.members} />
               <StyledDividingLine />
             </>
           )}
-          <Profile type="header" name={USER1.nickname} profileImg={USER1.profileImageUrl} id={USER1.id} />
+          {user && <Profile type="header" name={user.nickname} profileImg={user.profileImageUrl} id={user.id} />}
         </StyledRight>
       </StyledContainer>
     </StyledBody>
@@ -44,17 +64,28 @@ function Header({ page, children, crown }: Props) {
 
 export default Header;
 
-function HeaderButtons() {
+interface HeaderButtonsProps {
+  createdByMe?: boolean;
+}
+
+function HeaderButtons({ createdByMe }: HeaderButtonsProps) {
+  const router = useRouter();
+  const { id } = router.query;
+
   return (
     <StyledButtonSection>
-      <StyledSettingWrapper>
-        <Button.Plain style="outline" roundSize="L">
-          <StyledWrapper>
-            <StyledSettingIcon />
-            <StyledText>관리</StyledText>
-          </StyledWrapper>
-        </Button.Plain>
-      </StyledSettingWrapper>
+      {createdByMe && (
+        <Link href={`/board/${id}/edit`}>
+          <StyledSettingWrapper>
+            <Button.Plain style="outline" roundSize="L">
+              <StyledWrapper>
+                <StyledSettingIcon />
+                <StyledText>관리</StyledText>
+              </StyledWrapper>
+            </Button.Plain>
+          </StyledSettingWrapper>
+        </Link>
+      )}
       <StyledInviteWrapper>
         <Button.Plain style="outline" roundSize="L">
           <StyledWrapper>

--- a/components/common/Header/SecondHeader/SecondHeader.tsx
+++ b/components/common/Header/SecondHeader/SecondHeader.tsx
@@ -1,29 +1,27 @@
 import styled from 'styled-components';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { ReactNode, useEffect, useState } from 'react';
 import { BLACK, GRAY, WHITE } from '@/styles/ColorStyles';
 import { FONT_14, FONT_16, FONT_20_B } from '@/styles/FontStyles';
 import Button from '@/components/common/Button';
 import Profile from '@/components/common/Profile/Profile';
 import ProfileImgList from '@/components/common/Profile/ProfileImgList';
-import { USER1 } from '@/lib/constants/mockup';
-import { MEMBERS1 } from '@/lib/constants/mockup';
+import { getUserInfo } from '@/api/users/getUserInfo';
+import { UserType } from '@/lib/types/users';
+import { GetMemberListResponseType } from '@/lib/types/members';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { Z_INDEX } from '@/styles/ZIndexStyles';
 import Setting from '@/public/icon/settings.svg';
 import Invite from '@/public/icon/add_box.svg';
 import Crown from '@/public/icon/crown.svg';
 import { useStore } from '@/context/stores';
-import { useQuery } from '@tanstack/react-query';
-import { getUserInfo } from '@/api/users/getUserInfo';
-import { UserType } from '@/lib/types/users';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
 
 interface Props {
   page: 'myboard' | 'others';
   children: ReactNode;
   crown?: boolean;
-  membersData?: any;
+  membersData?: GetMemberListResponseType;
 }
 
 function Header({ page, children, crown, membersData }: Props) {
@@ -38,8 +36,6 @@ function Header({ page, children, crown, membersData }: Props) {
     fetchUser();
   }, []);
 
-  console.log(membersData);
-
   return (
     <StyledBody>
       <StyledContainer $page={page}>
@@ -51,7 +47,7 @@ function Header({ page, children, crown, membersData }: Props) {
           {page !== 'myboard' && (
             <>
               <HeaderButtons createdByMe={crown} />
-              <ProfileImgList memberCount={MEMBERS1.totalCount} data={MEMBERS1.members} />
+              {membersData && <ProfileImgList memberCount={membersData.totalCount} data={membersData.members} />}
               <StyledDividingLine />
             </>
           )}
@@ -69,6 +65,7 @@ interface HeaderButtonsProps {
 }
 
 function HeaderButtons({ createdByMe }: HeaderButtonsProps) {
+  const { modals, showModal } = useStore((state) => ({ modals: state.modals, showModal: state.showModal }));
   const router = useRouter();
   const { id } = router.query;
 
@@ -146,7 +143,7 @@ const StyledContainer = styled.div<{ $page: string }>`
 
 const StyledRight = styled.div`
   display: flex;
-  gap: 40px;
+  gap: 32px;
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     gap: 24px;

--- a/components/common/Header/SecondHeader/SecondHeader.tsx
+++ b/components/common/Header/SecondHeader/SecondHeader.tsx
@@ -16,6 +16,7 @@ import Setting from '@/public/icon/settings.svg';
 import Invite from '@/public/icon/add_box.svg';
 import Crown from '@/public/icon/crown.svg';
 import { useStore } from '@/context/stores';
+import InviteModal from '../../Modal/InviteModal';
 
 interface Props {
   page: 'myboard' | 'others';
@@ -65,33 +66,36 @@ interface HeaderButtonsProps {
 }
 
 function HeaderButtons({ createdByMe }: HeaderButtonsProps) {
-  const { modals, showModal } = useStore((state) => ({ modals: state.modals, showModal: state.showModal }));
+  const { modal, showModal } = useStore((state) => ({ modal: state.modals, showModal: state.showModal }));
   const router = useRouter();
   const { id } = router.query;
 
   return (
-    <StyledButtonSection>
-      {createdByMe && (
-        <Link href={`/board/${id}/edit`}>
-          <StyledSettingWrapper>
-            <Button.Plain style="outline" roundSize="L">
-              <StyledWrapper>
-                <StyledSettingIcon />
-                <StyledText>관리</StyledText>
-              </StyledWrapper>
-            </Button.Plain>
-          </StyledSettingWrapper>
-        </Link>
-      )}
-      <StyledInviteWrapper>
-        <Button.Plain style="outline" roundSize="L">
-          <StyledWrapper>
-            <StyledInviteIcon />
-            <StyledText>초대하기</StyledText>
-          </StyledWrapper>
-        </Button.Plain>
-      </StyledInviteWrapper>
-    </StyledButtonSection>
+    <>
+      <StyledButtonSection>
+        {createdByMe && (
+          <Link href={`/board/${id}/edit`}>
+            <StyledSettingWrapper>
+              <Button.Plain style="outline" roundSize="L">
+                <StyledWrapper>
+                  <StyledSettingIcon />
+                  <StyledText>관리</StyledText>
+                </StyledWrapper>
+              </Button.Plain>
+            </StyledSettingWrapper>
+          </Link>
+        )}
+        <StyledInviteWrapper>
+          <Button.Plain style="outline" roundSize="L" onClick={() => showModal('invite')}>
+            <StyledWrapper>
+              <StyledInviteIcon />
+              <StyledText>초대하기</StyledText>
+            </StyledWrapper>
+          </Button.Plain>
+        </StyledInviteWrapper>
+      </StyledButtonSection>
+      {modal.includes('invite') && <InviteModal dashboardId={Number(id)} />}
+    </>
   );
 }
 

--- a/components/common/Modal/AlertModal.tsx
+++ b/components/common/Modal/AlertModal.tsx
@@ -6,16 +6,20 @@ import { FONT_18 } from '@/styles/FontStyles';
 import { ReactNode } from 'react';
 import { useStore } from '@/context/stores';
 import { useRouter } from 'next/router';
+import { is } from 'date-fns/locale';
 
 interface Props {
   type: modalType;
+  customName?: string;
   children?: ReactNode;
   isSuccess?: boolean;
 }
 
-function AlertModal({ type, children, isSuccess }: Props) {
-  const { clearModal } = useStore((state) => ({
+function AlertModal({ type, children, isSuccess, customName }: Props) {
+  const router = useRouter();
+  const { clearModal, hideModal } = useStore((state) => ({
     clearModal: state.clearModal,
+    hideModal: state.hideModal,
   }));
   const getErrorMsg = (type: modalType): string | undefined => {
     let errorMsg;
@@ -47,9 +51,8 @@ function AlertModal({ type, children, isSuccess }: Props) {
     return errorMsg;
   };
 
-  const router = useRouter();
-
-  const handleButtonClick = (type: string, status?: string) => { 
+  const handleButtonClick = () => {
+    if (customName) return hideModal(customName);
     if (type === 'customAlert') {
       clearModal();
       if ((router.pathname === '/login' || '/signup') && isSuccess) {
@@ -59,7 +62,7 @@ function AlertModal({ type, children, isSuccess }: Props) {
   };
 
   return (
-    <ModalFrame type={type} title={''} height="High" btnFnc={() => handleButtonClick(type)}>
+    <ModalFrame type={type} title={''} height="High" btnFnc={handleButtonClick}>
       <ErrorMsgBox>
         <ErrorMsg>{type === 'customAlert' ? children : getErrorMsg(type)}</ErrorMsg>
       </ErrorMsgBox>

--- a/components/common/Modal/InviteModal.tsx
+++ b/components/common/Modal/InviteModal.tsx
@@ -1,0 +1,59 @@
+import { FormEvent, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useStore } from '@/context/stores';
+import Input from '@/components/common/Input/Input';
+import { emailRules } from '@/lib/constants/inputErrorRules';
+import { inviteDashboard } from '@/api/dashboards/inviteDashboard';
+import ModalFrame from './ModalFrame';
+import AlertModal from './AlertModal';
+
+interface Props {
+  dashboardId: number;
+}
+
+function InviteModal({ dashboardId }: Props) {
+  const [errorMsg, setErrorMsg] = useState();
+  const { modals, showModal } = useStore((state) => ({
+    modals: state.modals,
+    showModal: state.showModal,
+  }));
+  const {
+    register,
+    getValues,
+    formState: { errors },
+  } = useForm({ mode: 'onBlur' });
+  const email = getValues('email');
+
+  const handleInviteClick = async (event: FormEvent) => {
+    event.preventDefault();
+    const response = await inviteDashboard(dashboardId, { email });
+    if (response.status !== 201) {
+      setErrorMsg(response.data?.message);
+      showModal('inviteAlert');
+    }
+  };
+
+  return (
+    <>
+      <ModalFrame type="invite" title="초대하기" height="Mid" disabledBtn={errors.email} btnFnc={handleInviteClick}>
+        <form onSubmit={handleInviteClick}>
+          <Input
+            type="etc"
+            register={register('email', emailRules)}
+            error={errors.email}
+            initLabel="이메일"
+            initPlaceholder="초대할 이메일을 입력하세요"
+            isHookForm
+          />
+        </form>
+      </ModalFrame>
+      {modals[modals.length - 1] === 'inviteAlert' && (
+        <AlertModal type="customAlert" customName="inviteAlert">
+          {errorMsg}
+        </AlertModal>
+      )}
+    </>
+  );
+}
+
+export default InviteModal;

--- a/components/common/Modal/ModalFrame.tsx
+++ b/components/common/Modal/ModalFrame.tsx
@@ -7,9 +7,10 @@ import ModalPortal from './ModalPortal';
 import Button from '../Button';
 import DropDown from '@/components/common/DropDown/DropDown';
 import { Z_INDEX } from '@/styles/ZIndexStyles';
-import { FONT_14, FONT_24_B } from '@/styles/FontStyles';
+import { FONT_14, FONT_16, FONT_24_B } from '@/styles/FontStyles';
 import { BLACK } from '@/styles/ColorStyles';
 import { modalType } from '@/lib/types/zustand';
+import { DEVICE_SIZE } from '@/styles/DeviceSize';
 
 interface Props {
   height: 'Low' | 'Mid' | 'High' | 'Top';
@@ -62,6 +63,7 @@ function ModalFrame({ height, type, title, children, btnFnc, disabledBtn = false
                     '삭제'}
                   {(type === 'incorrectPWAlert' || type === 'imgUrl' || type === 'customAlert') && '확인'}
                   {type === 'editTodo' && '수정'}
+                  {type === 'invite' && '초대'}
                 </StyledButtonText>
               </Button.Plain>
             </StyledButtonWrapper>
@@ -167,5 +169,9 @@ const StyledButtonWrapper = styled.div`
 `;
 
 const StyledButtonText = styled.span`
-  ${FONT_14};
+  ${FONT_16};
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    ${FONT_14};
+  }
 `;

--- a/components/common/Profile/ProfileImg.tsx
+++ b/components/common/Profile/ProfileImg.tsx
@@ -1,6 +1,6 @@
 import { BLUE, GRAY, GREEN, ORANGE, PINK, PURPLE, WHITE } from '@/styles/ColorStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
-import { FONT_16 } from '@/styles/FontStyles';
+import { FONT_12, FONT_16 } from '@/styles/FontStyles';
 import Image from 'next/image';
 import styled from 'styled-components';
 
@@ -78,6 +78,8 @@ const StyledNickName = styled.div`
   opacity: 60%;
   background-color: ${GRAY[50]};
 
+  ${FONT_12};
+  color: ${WHITE};
   border-radius: 30px;
   word-break: keep-all;
 `;

--- a/components/common/Profile/ProfileImgList.tsx
+++ b/components/common/Profile/ProfileImgList.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { FONT_14, FONT_16 } from '@/styles/FontStyles';
+import { FONT_14, FONT_14_B, FONT_16, FONT_16_B } from '@/styles/FontStyles';
 import { Z_INDEX } from '@/styles/ZIndexStyles';
 import { PINK, WHITE } from '@/styles/ColorStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
@@ -42,8 +42,8 @@ function ProfileImgList({ memberCount, data }: Props) {
           </StyledProfileWrapper>
         )}
       </StyledWrapper>
-      <StyledPCRest $order={5}>+{PcRest <= 999 ? PcRest : '999'}</StyledPCRest>
-      <StyledTabletRest $order={3}>+{TabletRest <= 999 ? TabletRest : '999'}</StyledTabletRest>
+      {memberCount > 4 && <StyledPCRest $order={5}>+{PcRest <= 999 ? PcRest : '999'}</StyledPCRest>}
+      {memberCount > 2 && <StyledTabletRest $order={3}>+{TabletRest <= 999 ? TabletRest : '999'}</StyledTabletRest>}
     </StyledContainer>
   );
 }
@@ -51,41 +51,23 @@ function ProfileImgList({ memberCount, data }: Props) {
 export default ProfileImgList;
 
 const StyledContainer = styled.div`
-  min-width: 156px;
-
-  position: relative;
+  padding-left: 10px;
 
   display: flex;
   justify-content: flex-start;
   align-items: center;
-
-  @media (max-width: ${DEVICE_SIZE.tablet}) {
-    min-width: 100px;
-  }
-
-  @media (max-width: ${DEVICE_SIZE.mobile}) {
-    min-width: 95px;
-  }
 `;
 
 const StyledProfileWrapper = styled.div<{ $order: number }>`
-  position: absolute;
-  left: ${({ $order }) => `${29 * $order - 29}px`};
-
+  margin-left: -10px;
   z-index: ${({ $order }) => $order};
-
-  @media (max-width: ${DEVICE_SIZE.mobile}) {
-    left: ${({ $order }) => `${25 * $order - 25}px`};
-  }
 `;
 
 const StyledRest = styled.div<{ $order: number }>`
   min-width: 38px;
   height: 38px;
   padding: 0.6rem 0.5rem;
-
-  position: absolute;
-  left: ${({ $order }) => `${29 * $order - 29}px`};
+  margin-left: -10px;
 
   z-index: ${Z_INDEX.profileImgList_Rest};
 
@@ -98,17 +80,14 @@ const StyledRest = styled.div<{ $order: number }>`
 
   background-color: ${PINK[2]};
 
-  ${FONT_16}
+  ${FONT_16_B}
   color: ${PINK[3]};
-  text-align: center;
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     min-width: 34px;
     height: 34px;
 
-    left: ${({ $order }) => `${25 * $order - 25}px`};
-
-    ${FONT_14};
+    ${FONT_14_B};
   }
 `;
 
@@ -127,6 +106,7 @@ const StyledTabletRest = styled(StyledRest)`
 `;
 
 const StyledWrapper = styled(StyledContainer)`
+  margin-left: -10px;
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     display: none;
   }

--- a/components/common/Profile/ProfileImgList.tsx
+++ b/components/common/Profile/ProfileImgList.tsx
@@ -18,6 +18,8 @@ function ProfileImgList({ memberCount, data }: Props) {
   const PcRest = memberCount - 4;
   const TabletRest = memberCount - 2;
 
+  if (!memberCount) return;
+
   return (
     <StyledContainer>
       {data[0] && (

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-const authauthInstance = axios.create({});
+const authInstance = axios.create({});
 
-authauthInstance.interceptors.request.use((config) => {
+authInstance.interceptors.request.use((config) => {
   const accessToken = window.localStorage.getItem('login');
 
   if (accessToken) config.headers.Authorization = `Bearer ${accessToken}`;
@@ -10,4 +10,4 @@ authauthInstance.interceptors.request.use((config) => {
   return config;
 });
 
-export default authauthInstance;
+export default authInstance;

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
-const instance = axios.create({});
+const authauthInstance = axios.create({});
 
-instance.interceptors.request.use((config) => {
+authauthInstance.interceptors.request.use((config) => {
   const accessToken = window.localStorage.getItem('login');
 
   if (accessToken) config.headers.Authorization = `Bearer ${accessToken}`;
@@ -10,4 +10,4 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
-export default instance;
+export default authauthInstance;

--- a/lib/types/zustand.ts
+++ b/lib/types/zustand.ts
@@ -17,7 +17,9 @@ export type modalType =
   | 'signUpFailedAlert'
   | 'customAlert'
   | 'profile'
-  | 'editPassword';
+  | 'editPassword'
+  | 'invite'
+  | 'inviteAlert';
 
 export interface ModalState {
   modals: modalType[];

--- a/pages/board/[id]/edit.tsx
+++ b/pages/board/[id]/edit.tsx
@@ -12,31 +12,37 @@ import DashMyMember from '@/components/common/Table/DashMyMember';
 import DashInviteList from '@/components/common/Table/DashInviteList';
 import { MEMBERS1 } from '@/lib/constants/mockup';
 import boardMockData from '@/components/common/SideMenu/mock';
+import Head from 'next/head';
 
 function Edit() {
   const router = useRouter();
   const { id } = router.query;
   return (
-    <Root>
-      <Second page="others" children="제목" />
-      <SideMenu dashboards={boardMockData.dashboards} />
-      <Content>
-        <Wrapper>
-          <ButtonLink href={`/board/${id}`}>
-            <ReturnButton>
-              <ArrowPosition>
-                <ArrowBackward />
-              </ArrowPosition>
-              <ButtonText>돌아가기</ButtonText>
-            </ReturnButton>
-          </ButtonLink>
-          <EditMyDash />
-          <DashMyMember memberList={MEMBERS1} />
-          <DashInviteList memberList={MEMBERS1} />
-          <DeleteDashButton>대시보드 삭제하기</DeleteDashButton>
-        </Wrapper>
-      </Content>
-    </Root>
+    <>
+      <Head>
+        <title>대시보드 관리 | Taskify</title>
+      </Head>
+      <Root>
+        <Second page="others" children="제목" />
+        <SideMenu dashboards={boardMockData.dashboards} />
+        <Content>
+          <Wrapper>
+            <ButtonLink href={`/board/${id}`}>
+              <ReturnButton>
+                <ArrowPosition>
+                  <ArrowBackward />
+                </ArrowPosition>
+                <ButtonText>돌아가기</ButtonText>
+              </ReturnButton>
+            </ButtonLink>
+            <EditMyDash />
+            <DashMyMember memberList={MEMBERS1} />
+            <DashInviteList memberList={MEMBERS1} />
+            <DeleteDashButton>대시보드 삭제하기</DeleteDashButton>
+          </Wrapper>
+        </Content>
+      </Root>
+    </>
   );
 }
 

--- a/pages/board/[id]/index.tsx
+++ b/pages/board/[id]/index.tsx
@@ -17,7 +17,7 @@ import { getDashboardList } from '@/api/dashboards/getDashboardList';
 import { getColumnList } from '@/api/columns/getColumnList';
 import { getMemberList } from '@/api/members/getMemberList';
 import { DashboardType } from '@/lib/types/dashboards';
-import { MemberListType } from '@/lib/types/members';
+import { GetMemberListResponseType } from '@/lib/types/members';
 import { ColumnType } from '@/lib/types/columns';
 import { useStore } from '@/context/stores';
 import Head from 'next/head';
@@ -26,7 +26,7 @@ function Board() {
   const [currentDashboard, setCurrentDashboard] = useState<DashboardType>();
   const [dashboardList, setDashboardList] = useState<DashboardType[]>([]);
   const [columnList, setColumnList] = useState<ColumnType[]>([]);
-  const [memberList, setMemberList] = useState<MemberListType[]>([]);
+  const [memberList, setMemberList] = useState<GetMemberListResponseType>();
   const [isColumnChanged, setIsColumnChanged] = useState<boolean>(false);
 
   const modal = useStore((state) => state.modals);
@@ -93,7 +93,7 @@ function Board() {
               id={Number(id)}
               isColumnChanged={isColumnChanged}
               setIsColumnChanged={setIsColumnChanged}
-              memberList={memberList.members}
+              memberList={memberList?.members}
             />
           )}
           <StyledBtnWrapper>

--- a/pages/board/[id]/index.tsx
+++ b/pages/board/[id]/index.tsx
@@ -60,7 +60,7 @@ function Board() {
       if (!currentDashboard) return;
 
       const resMemberList = await getMemberList(currentDashboard.id);
-      setMemberList(resMemberList.members);
+      setMemberList(resMemberList); //헤더에서 totalCount 데이터가 필요해서 이 부분 수정했어요!
     };
 
     fetchMemberData();
@@ -93,7 +93,7 @@ function Board() {
               id={Number(id)}
               isColumnChanged={isColumnChanged}
               setIsColumnChanged={setIsColumnChanged}
-              memberList={memberList}
+              memberList={memberList.members}
             />
           )}
           <StyledBtnWrapper>

--- a/pages/board/[id]/index.tsx
+++ b/pages/board/[id]/index.tsx
@@ -20,6 +20,7 @@ import { DashboardType } from '@/lib/types/dashboards';
 import { MemberListType } from '@/lib/types/members';
 import { ColumnType } from '@/lib/types/columns';
 import { useStore } from '@/context/stores';
+import Head from 'next/head';
 
 function Board() {
   const [currentDashboard, setCurrentDashboard] = useState<DashboardType>();
@@ -73,33 +74,43 @@ function Board() {
   };
 
   return (
-    <StyledRoot>
-      <Header page="others" children={currentDashboard?.title} crown={currentDashboard?.createdByMe} />
-      <SideMenu dashboards={dashboardList} />
-      <StyledContent>
-        {columnList.length > 0 && (
-          <ColumnLists
-            columnList={columnList}
-            id={Number(id)}
-            isColumnChanged={isColumnChanged}
-            setIsColumnChanged={setIsColumnChanged}
-            memberList={memberList}
+    <>
+      <Head>
+        <title>{`${currentDashboard?.title} | Taskify`}</title>
+      </Head>
+      <StyledRoot>
+        <Header
+          page="others"
+          children={currentDashboard?.title}
+          crown={currentDashboard?.createdByMe}
+          membersData={memberList}
+        />
+        <SideMenu dashboards={dashboardList} />
+        <StyledContent>
+          {columnList.length > 0 && (
+            <ColumnLists
+              columnList={columnList}
+              id={Number(id)}
+              isColumnChanged={isColumnChanged}
+              setIsColumnChanged={setIsColumnChanged}
+              memberList={memberList}
+            />
+          )}
+          <StyledBtnWrapper>
+            <Button.Add roundSize="L" onClick={handleAddColumnBtn}>
+              <StyledText>새로운 컬럼 추가하기</StyledText>
+            </Button.Add>
+          </StyledBtnWrapper>
+        </StyledContent>
+        {modal[modal.length - 1] === 'createColumn' && (
+          <ColumnModal
+            type={'createColumn'}
+            dashboardID={Number(id)}
+            refreshColumn={() => setIsColumnChanged(!isColumnChanged)}
           />
         )}
-        <StyledBtnWrapper>
-          <Button.Add roundSize="L" onClick={handleAddColumnBtn}>
-            <StyledText>새로운 컬럼 추가하기</StyledText>
-          </Button.Add>
-        </StyledBtnWrapper>
-      </StyledContent>
-      {modal[modal.length - 1] === 'createColumn' && (
-        <ColumnModal
-          type={'createColumn'}
-          dashboardID={Number(id)}
-          refreshColumn={() => setIsColumnChanged(!isColumnChanged)}
-        />
-      )}
-    </StyledRoot>
+      </StyledRoot>
+    </>
   );
 }
 
@@ -114,8 +125,6 @@ const StyledContent = styled.div`
 
   display: flex;
   flex-direction: row;
-
-  background-color: ${GRAY[10]};
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     padding-top: 70px;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -14,6 +14,7 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { login } from '@/api/auth/login';
 import { emailRules, signInPwRules } from '@/lib/constants/inputErrorRules';
 import { useStore } from '@/context/stores';
+import Head from 'next/head';
 
 function Login() {
   const [message, setMessage] = useState('');
@@ -60,38 +61,43 @@ function Login() {
   };
 
   return (
-    <StyledRoot>
-      <StyledContainer>
-        <Link href="/">
-          <StyledLogo src="/images/logo_main.svg" alt="Main logo" />
-        </Link>
-        <StyledWord>오늘도 만나서 반가워요!</StyledWord>
-        <StyledForm onSubmit={handleSubmit(handleLogin)}>
-          <Input type="email" register={register('email', emailRules)} error={errors.email} isHookForm />
-          <Input
-            type="password"
-            isPassword
-            register={register('password', signInPwRules)}
-            error={errors.password}
-            isHookForm
-          />
-          <StyledButtonWrapper>
-            <Button.Plain style="primary" roundSize="L" isNotActive={isLoading}>
-              로그인
-            </Button.Plain>
-            {isLoading && <Spinner />}
-          </StyledButtonWrapper>
-          <StyledWrapper>
-            회원이 아니신가요? <Link href="/signup">회원가입하기</Link>
-          </StyledWrapper>
-        </StyledForm>
-        {modals[modals.length - 1] === 'customAlert' && (
-          <AlertModal type="customAlert" isSuccess={isSuccess}>
-            {message}
-          </AlertModal>
-        )}
-      </StyledContainer>
-    </StyledRoot>
+    <>
+      <Head>
+        <title>로그인 | Taskify</title>
+      </Head>
+      <StyledRoot>
+        <StyledContainer>
+          <Link href="/">
+            <StyledLogo src="/images/logo_main.svg" alt="Main logo" />
+          </Link>
+          <StyledWord>오늘도 만나서 반가워요!</StyledWord>
+          <StyledForm onSubmit={handleSubmit(handleLogin)}>
+            <Input type="email" register={register('email', emailRules)} error={errors.email} isHookForm />
+            <Input
+              type="password"
+              isPassword
+              register={register('password', signInPwRules)}
+              error={errors.password}
+              isHookForm
+            />
+            <StyledButtonWrapper>
+              <Button.Plain style="primary" roundSize="L" isNotActive={isLoading}>
+                로그인
+              </Button.Plain>
+              {isLoading && <Spinner />}
+            </StyledButtonWrapper>
+            <StyledWrapper>
+              회원이 아니신가요? <Link href="/signup">회원가입하기</Link>
+            </StyledWrapper>
+          </StyledForm>
+          {modals[modals.length - 1] === 'customAlert' && (
+            <AlertModal type="customAlert" isSuccess={isSuccess}>
+              {message}
+            </AlertModal>
+          )}
+        </StyledContainer>
+      </StyledRoot>
+    </>
   );
 }
 

--- a/pages/myboard/index.tsx
+++ b/pages/myboard/index.tsx
@@ -11,6 +11,7 @@ import { useStore } from '@/context/stores';
 import { getInvitationList } from '@/api/invitations/getInvitationList';
 import { inviteDashboard } from '@/api/dashboards/inviteDashboard';
 import { GetInvitationResponseType } from '@/lib/types/invitations';
+import Head from 'next/head';
 
 function Myboard() {
   const { page, setTotal, search } = useStore((state) => ({
@@ -52,6 +53,9 @@ function Myboard() {
 
   return (
     <>
+      <Head>
+        <title>내 대시보드 | Taskify</title>
+      </Head>
       <Header page="myboard">내 대시보드</Header>
       <SideMenu dashboards={dashboardList} />
       <StyledBody>

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -9,6 +9,7 @@ import { getUserInfo } from '@/api/users/getUserInfo';
 import { UserType } from '@/lib/types/users';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import dashboardData from '@/components/common/SideMenu/mock';
+import Head from 'next/head';
 
 function MyPage() {
   const [userData, setUserData] = useState<UserType>();
@@ -24,6 +25,9 @@ function MyPage() {
 
   return (
     <>
+      <Head>
+        <title>계정관리 | Taskify</title>
+      </Head>
       <Header page="myboard">계정관리</Header>
       <SideMenu data={dashboardData.dashboards} />
       <StyledBody>

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -20,6 +20,7 @@ import {
   signUpPasswordCheckRules,
 } from '@/lib/constants/inputErrorRules';
 import { useStore } from '@/context/stores';
+import Head from 'next/head';
 
 function SignUp() {
   const [message, setMessage] = useState('');
@@ -72,52 +73,57 @@ function SignUp() {
   };
 
   return (
-    <StyledRoot>
-      <StyledContainer>
-        <Link href="/">
-          <StyledLogo src="/images/logo_main.svg" alt="Main logo" />
-        </Link>
-        <StyledWord>첫 방문을 환영합니다!</StyledWord>
-        <StyledForm onSubmit={handleSubmit(onSubmit)}>
-          <Input type="email" register={register('email', emailRules)} error={errors.email} isHookForm={true} />
-          <Input
-            type="nickname"
-            register={register('nickname', nicknameRules)}
-            error={errors.nickname}
-            isHookForm={true}
-          />
-          <Input
-            type="password"
-            isPassword
-            register={register('password', signUpPasswordRules)}
-            error={errors.password}
-            isHookForm={true}
-          />
-          <Input
-            type="passwordConfirm"
-            isPassword
-            register={register('passwordCheck', signUpPasswordCheckRules(passwordValue))}
-            error={errors.passwordCheck}
-            isHookForm={true}
-          />
-          <Checkbox label="이용약관에 동의합니다." onChange={() => setIsChecked(!isChecked)} />
-          <StyledButtonWrapper>
-            <Button.Plain type="submit" style="primary" roundSize="L" isNotActive={!isButtonActive || isLoading}>
-              가입하기
-            </Button.Plain>
-            {isLoading && <Spinner />}
-          </StyledButtonWrapper>
-          <StyledWrapper>
-            이미 가입하셨나요? <Link href="/login">로그인하기</Link>
-          </StyledWrapper>
-        </StyledForm>
-        {modals[modals.length - 1] === 'customAlert' && (
-          <AlertModal type="customAlert" isSuccess={isSuccess}>
-            {message}
-          </AlertModal>
-        )}
-      </StyledContainer>
-    </StyledRoot>
+    <>
+      <Head>
+        <title>회원가입 | Taskify</title>
+      </Head>
+      <StyledRoot>
+        <StyledContainer>
+          <Link href="/">
+            <StyledLogo src="/images/logo_main.svg" alt="Main logo" />
+          </Link>
+          <StyledWord>첫 방문을 환영합니다!</StyledWord>
+          <StyledForm onSubmit={handleSubmit(onSubmit)}>
+            <Input type="email" register={register('email', emailRules)} error={errors.email} isHookForm={true} />
+            <Input
+              type="nickname"
+              register={register('nickname', nicknameRules)}
+              error={errors.nickname}
+              isHookForm={true}
+            />
+            <Input
+              type="password"
+              isPassword
+              register={register('password', signUpPasswordRules)}
+              error={errors.password}
+              isHookForm={true}
+            />
+            <Input
+              type="passwordConfirm"
+              isPassword
+              register={register('passwordCheck', signUpPasswordCheckRules(passwordValue))}
+              error={errors.passwordCheck}
+              isHookForm={true}
+            />
+            <Checkbox label="이용약관에 동의합니다." onChange={() => setIsChecked(!isChecked)} />
+            <StyledButtonWrapper>
+              <Button.Plain type="submit" style="primary" roundSize="L" isNotActive={!isButtonActive || isLoading}>
+                가입하기
+              </Button.Plain>
+              {isLoading && <Spinner />}
+            </StyledButtonWrapper>
+            <StyledWrapper>
+              이미 가입하셨나요? <Link href="/login">로그인하기</Link>
+            </StyledWrapper>
+          </StyledForm>
+          {modals[modals.length - 1] === 'customAlert' && (
+            <AlertModal type="customAlert" isSuccess={isSuccess}>
+              {message}
+            </AlertModal>
+          )}
+        </StyledContainer>
+      </StyledRoot>
+    </>
   );
 }
 


### PR DESCRIPTION
## 수정 내용

- 헤더에 **관리, 초대하기 버튼 기능 추가**하였습니다.
- 관리 버튼은 대시보드 관리자에게만 보이도록 설정하였습니다.
- 헤더에서 유저 정보 불러와서 유저 정보 업데이트했습니다!
- 결국 id로 데이터 직접 부르는 건 해결을 못해서 멤버 데이터만 직접 넘겨주세요 🥹🥹💦💦

## 스크린샷
현재 로그인 데이터 연동된 헤더
<img width="938" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/d7fb1432-f9a2-471d-a209-f8057ed290e1">


## 기타
- 멤버 데이터에서 totalCount 값이 필요해서 **유진님 memberList 타입을 수정**했어요..ㅠㅠ 주석 달아놨으니까 이 부분 확인 부탁드려요!
- 다른 초대하기 구현하시는 분들도 제가 InviteModal 없길래 만들어 놨으니까 쓰시면 될 것 같아요!
TT-124 TT-115
