### PR TITLE
[이태희] board/id/Edit 페이지 리펙토링

### DIFF
--- a/components/common/Modal/InviteModal.tsx
+++ b/components/common/Modal/InviteModal.tsx
@@ -31,7 +31,10 @@ function InviteModal({ dashboardId }: Props) {
     if (response.status !== 201) {
       setErrorMsg(response.data?.message);
       showModal('inviteAlert');
-    } else clearModal();
+    } else {
+      clearModal();
+      window.location.reload();
+    }
   };
 
   return (

--- a/components/common/Table/DashInviteList.tsx
+++ b/components/common/Table/DashInviteList.tsx
@@ -8,6 +8,7 @@ import { GetDashboardInvitationResponseType } from '@/lib/types/dashboards';
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { getDashboardInvitationList } from '@/api/dashboards/getDashboardInvitationList';
+import NoDashImg from '@/public/images/No_Invite_Dash.svg';
 
 // interface Props {
 //   invitationsList: GetDashboardInvitationResponseType;
@@ -42,21 +43,30 @@ function DashInviteList() {
     <Wrapper>
       <Container>
         <ListHeader title="초대 내역" totalCount={totalCount} page={page} getPage={getPage} />
-        <ListTitle>이메일</ListTitle>
-        <ListLayout>
-          {invitations.map((invitation) => (
-            <InviterEmailWrapper key={invitation.id}>
-              <InviterEmailLayout>
-                <InviteEmail>{invitation.invitee.email}</InviteEmail>
-                <InviteCancelButton>
-                  <Button.Plain style="outline" roundSize="S">
-                    <ButtonText>취소</ButtonText>
-                  </Button.Plain>
-                </InviteCancelButton>
-              </InviterEmailLayout>
-            </InviterEmailWrapper>
-          ))}
-        </ListLayout>
+        {invitations.length === 0 ? (
+          <NullWrapper>
+            <NoDashImg />
+            <NullInviteList>초대내역이 없습니다.</NullInviteList>
+          </NullWrapper>
+        ) : (
+          <>
+            <ListTitle>이메일</ListTitle>
+            <ListLayout>
+              {invitations.map((invitation) => (
+                <InviterEmailWrapper key={invitation.id}>
+                  <InviterEmailLayout>
+                    <InviteEmail>{invitation.invitee.email}</InviteEmail>
+                    <InviteCancelButton>
+                      <Button.Plain style="outline" roundSize="S">
+                        <ButtonText>취소</ButtonText>
+                      </Button.Plain>
+                    </InviteCancelButton>
+                  </InviterEmailLayout>
+                </InviterEmailWrapper>
+              ))}
+            </ListLayout>
+          </>
+        )}
       </Container>
     </Wrapper>
   );
@@ -137,4 +147,17 @@ const InviteCancelButton = styled.div`
 `;
 const ButtonText = styled.div`
   color: ${[VIOLET[1]]};
+`;
+const NullInviteList = styled.div``;
+
+const NullWrapper = styled.div`
+  height: 410px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    height: 340px;
+  }
 `;

--- a/components/common/Table/DashMyMember.tsx
+++ b/components/common/Table/DashMyMember.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { GetMemberListResponseType } from '@/lib/types/members';
 import { getMemberList } from '@/api/members/getMemberList';
+import Crown from '@/public/icon/crown.svg';
 
 function DashMyMember() {
   const isMobile = useMediaQuery({ query: `(max-width: ${DEVICE_SIZE.mobile})` });
@@ -47,7 +48,9 @@ function DashMyMember() {
         <Header>
           <Title>구성원</Title>
           <ArrowButton>
-            <PageStatus>1 페이지 중 1</PageStatus>
+            <PageStatus>
+              {totalPage} 페이지 중 {page}
+            </PageStatus>
             <ButtonLayout>
               <Button.Arrow type="left" isNotActive={page === 1 ? true : false} onClick={handleButtonPrevPage} />
               <Button.Arrow
@@ -60,7 +63,7 @@ function DashMyMember() {
         </Header>
         <ListTitle>이름</ListTitle>
         <ListLayout>
-          {members.map((member) => (
+          {members.map((member, index) => (
             <MemberWrapper key={member.id}>
               <MemberNameLayout>
                 <ProfileImgLayout>
@@ -73,11 +76,15 @@ function DashMyMember() {
                 </ProfileImgLayout>
                 <NameLayout>
                   <MemberName>{member.nickname}</MemberName>
-                  <MemberDeleteButton>
-                    <Button.Plain style="secondary" roundSize="S">
-                      <ButtonText>삭제</ButtonText>
-                    </Button.Plain>
-                  </MemberDeleteButton>
+                  {index === 0 && page === 1 ? (
+                    <StyledCrown />
+                  ) : (
+                    <MemberDeleteButton>
+                      <Button.Plain style="secondary" roundSize="S">
+                        <ButtonText>삭제</ButtonText>
+                      </Button.Plain>
+                    </MemberDeleteButton>
+                  )}
                 </NameLayout>
               </MemberNameLayout>
             </MemberWrapper>
@@ -206,5 +213,12 @@ const PageStatus = styled.div`
   ${[FONT_14]}
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     ${[FONT_12]}
+  }
+`;
+
+const StyledCrown = styled(Crown)`
+  margin-right: 30px;
+  @media (max-width: ${DEVICE_SIZE.mobile}) {
+    margin-right: 15px;
   }
 `;

--- a/components/common/Table/EditMyDash.tsx
+++ b/components/common/Table/EditMyDash.tsx
@@ -1,12 +1,13 @@
 import { styled } from 'styled-components';
 import { BLUE, GRAY, GREEN, ORANGE, PINK, PURPLE, WHITE } from '@/styles/ColorStyles';
 import { FONT_14, FONT_16, FONT_18, FONT_20_B } from '@/styles/FontStyles';
-import React, { useEffect, useState } from 'react';
+import React, { SetStateAction, useEffect, useState } from 'react';
 import DashBoardColor from '../Chip/DashBoardColor';
 import Button from '../Button';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { GetDashboardListDetailResponseType } from '@/lib/types/dashboards';
 import { editDashboard } from '@/api/dashboards/editDashboard';
+import { tree } from 'next/dist/build/templates/app-page';
 
 interface Props {
   dashboardData: GetDashboardListDetailResponseType;

--- a/components/common/Table/ListHeader.tsx
+++ b/components/common/Table/ListHeader.tsx
@@ -23,7 +23,7 @@ function ListHeader({ title = '구성원', totalCount, page = 1, getPage }: List
   const router = useRouter();
   const { id } = router.query;
   const totalPage = Math.ceil(totalCount / 5);
-  console.log(totalPage);
+
   const handleButtonNextPage = () => {
     getPage(page + 1);
   };
@@ -38,14 +38,14 @@ function ListHeader({ title = '구성원', totalCount, page = 1, getPage }: List
       {title === '초대 내역' && (
         <HeaderRight>
           <PageStatus>
-            {totalPage} 페이지 중 {page}
+            {totalPage === 0 ? 1 : totalPage} 페이지 중 {page}
           </PageStatus>
           <ArrowButton>
             <ButtonLayout>
-              <Button.Arrow type="left" isNotActive={page === 1 ? true : false} onClick={handleButtonPrevPage} />
+              <Button.Arrow type="left" isNotActive={page <= 1 ? true : false} onClick={handleButtonPrevPage} />
               <Button.Arrow
                 type="right"
-                isNotActive={totalPage === page ? true : false}
+                isNotActive={totalPage <= page ? true : false}
                 onClick={handleButtonNextPage}
               />
             </ButtonLayout>

--- a/pages/board/[id]/edit.tsx
+++ b/pages/board/[id]/edit.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import styled from 'styled-components';
-import ArrowIcon from '@/public/icon/arrow_backward.svg';
 import Second from '@/components/common/Header/SecondHeader/SecondHeader';
 import SideMenu from '@/components/common/SideMenu/SideMenu';
 import { FONT_16, FONT_18 } from '@/styles/FontStyles';
@@ -10,17 +9,14 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import EditMyDash from '@/components/common/Table/EditMyDash';
 import DashMyMember from '@/components/common/Table/DashMyMember';
 import DashInviteList from '@/components/common/Table/DashInviteList';
-import { MEMBERS1 } from '@/lib/constants/mockup';
 import boardMockData from '@/components/common/SideMenu/mock';
 
 import { useEffect } from 'react';
 import { useState } from 'react';
-import { MemberList } from '@/lib/types/type';
 import { getDashboardInfo } from '@/api/dashboards/getDashboardInfo';
 import { GetDashboardListDetailResponseType } from '@/lib/types/dashboards';
 import BackButton from '@/components/pages/mypage/BackButton';
-import { getDashboardInvitationList } from '@/api/dashboards/getDashboardInvitationList';
-
+import { useCheckLogin } from '@/hooks/useCheckLogin';
 
 function Edit() {
   useCheckLogin();
@@ -61,7 +57,7 @@ function Edit() {
   return (
     <Root>
       <Second page="others" children="제목" />
-      <SideMenu dashboards={boardMockData.dashboards} />
+      <SideMenu />
       <Content>
         <Wrapper>
           <ButtonLink href={`/board/${id}`}>


### PR DESCRIPTION
## 수정 내용

- 구성원 관리자 표시
- 초대내역이 없을 경우 보여주는 이미지
-  초대 내역이 없을경우 페이지네이션 버튼 수정

## (선택) 스크린샷

![구성원 대시보드 관리자 왕관표시](https://github.com/like-tenten/tenten/assets/69644470/c36a1609-e8bc-4934-a237-4f02ad98ca89)
![초대내역 초대자가 없을경우](https://github.com/like-tenten/tenten/assets/69644470/1db1e112-c792-4172-8663-d37b548b749b)



## 기타
