### PR TITLE
[안희원] 컬러칩 커스텀 기능 추가 & 헤더 멤버 드롭다운

### DIFF
--- a/api/dashboards/inviteDashboard.ts
+++ b/api/dashboards/inviteDashboard.ts
@@ -1,5 +1,6 @@
 import authInstance from '@/lib/axios';
 import { PostDashboardInvitationRequestType } from '@/lib/types/dashboards';
+import { toast } from 'react-toastify';
 
 /**
  * 대시보드 초대하기
@@ -7,7 +8,7 @@ import { PostDashboardInvitationRequestType } from '@/lib/types/dashboards';
 export const inviteDashboard = async (dashboardId: number, data: PostDashboardInvitationRequestType) => {
   try {
     const response = await authInstance.post(`/api/dashboards/${dashboardId}/invitations`, data);
-    alert('초대에 성공했어요!');
+    toast.success('초대에 성공했어요!');
     return response;
   } catch (error: any) {
     return error.response;

--- a/components/common/Chip/ColorChoice.tsx
+++ b/components/common/Chip/ColorChoice.tsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import { FONT_16 } from '@/styles/FontStyles';
+import { BLACK, GRAY, VIOLET } from '@/styles/ColorStyles';
+import { Dispatch, SetStateAction, useState } from 'react';
+import DashBoardColor from '../Chip/DashBoardColor';
+
+interface Props {
+  type?: string;
+  color: string;
+  setColor: Dispatch<SetStateAction<string>>;
+}
+
+function ColorChoice({ type = 'create', color, setColor }: Props) {
+  const [colorTheme, setColorTheme] = useState('pastel');
+
+  return (
+    <StyledColorWrapper $type={type}>
+      {type !== 'edit' && <StyledText>색상 선택</StyledText>}
+      <StyledThemeWrapper>
+        <StyledTheme $isSelected={'pastel' === colorTheme} onClick={() => setColorTheme('pastel')}>
+          PASTEL
+        </StyledTheme>
+        <StyledTheme $isSelected={'vivid' === colorTheme} onClick={() => setColorTheme('vivid')}>
+          VIVID
+        </StyledTheme>
+        <StyledTheme $isSelected={'custom' === colorTheme} onClick={() => setColorTheme('custom')}>
+          CUSTOM
+        </StyledTheme>
+      </StyledThemeWrapper>
+      <StyledChipWrapper>
+        <DashBoardColor theme={colorTheme} selectedColor={color} setSelectedColor={setColor} isInModal={true} />
+      </StyledChipWrapper>
+    </StyledColorWrapper>
+  );
+}
+
+export default ColorChoice;
+
+const StyledColorWrapper = styled.div<{ $type: string }>`
+  margin-top: ${(props) => (props.$type === 'edit' ? '0px' : '20px')};
+
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const StyledText = styled.div`
+  ${FONT_16};
+  color: ${BLACK[2]};
+`;
+
+const StyledThemeWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const StyledTheme = styled.div<{ $isSelected: boolean }>`
+  width: 75px;
+  padding: 5px 8px;
+
+  display: flex;
+  justify-content: center;
+
+  border: 1px solid ${GRAY[30]};
+  border-radius: 10px;
+
+  color: ${(props) => (props.$isSelected ? `${VIOLET[1]}` : null)};
+  background-color: ${(props) => (props.$isSelected ? `${VIOLET[8]}` : null)};
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${VIOLET[8]};
+  }
+`;
+
+const StyledChipWrapper = styled.div`
+  margin-top: 10px;
+  justify-content: flex-start;
+`;

--- a/components/common/Chip/DashBoardColor.tsx
+++ b/components/common/Chip/DashBoardColor.tsx
@@ -1,10 +1,15 @@
-import { SetStateAction } from 'react';
+import { FormEvent, SetStateAction, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import DoneIcon from '@/public/icon/done_Fillo.svg';
-import { GREEN, PURPLE, ORANGE, BLUE, PINK } from '@/styles/ColorStyles';
+import { GREEN, PURPLE, ORANGE, BLUE, PINK, GRAY, RED, VIOLET } from '@/styles/ColorStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
+import { useForm } from 'react-hook-form';
+import { FONT_12, FONT_14 } from '@/styles/FontStyles';
+import Button from '../Button';
+import { colorCodeRules } from '@/lib/constants/inputErrorRules';
 
 interface Props {
+  theme: 'pastel' | 'vivid' | 'custom' | string;
   selectedColor: string;
   setSelectedColor: (value: SetStateAction<string>) => void;
   isInModal?: boolean;
@@ -15,10 +20,42 @@ interface Props {
  * @param setSelectedColor 색상을 선택할 때 호출되는 함수. 선택된 색상을 인수로 받습니다.
  */
 
-function DashBoardColor({ selectedColor, setSelectedColor, isInModal }: Props) {
-  const colors = [GREEN, PURPLE, ORANGE, BLUE, PINK[1]];
+function DashBoardColor({ theme, selectedColor, setSelectedColor, isInModal }: Props) {
+  const PASTEL = [GREEN[0], PURPLE[0], ORANGE[0], BLUE[0], PINK[0]];
+  const VIVID = [GREEN[1], PURPLE[1], ORANGE[1], BLUE[1], PINK[1]];
+  const colors = theme === 'pastel' ? PASTEL : VIVID;
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useForm({ mode: 'onBlur' });
+  const customColorCode = watch('customColor');
+  const isError = errors.customColor ? true : false;
 
-  return (
+  return theme === 'custom' ? (
+    <StyledInputWrapper>
+      <StyledErrorWrapper>
+        <StyledInput
+          $isError={isError}
+          {...register('customColor', colorCodeRules)}
+          placeholder="#FFFFFF 형식으로 입력하세요"
+        />
+        {errors.customColor && <StyledErrorMsg>{errors.customColor.message}</StyledErrorMsg>}
+      </StyledErrorWrapper>
+      <StyledButtonWrapper>
+        <Button.Plain
+          style="primary"
+          roundSize="L"
+          isNotActive={isError || !customColorCode || selectedColor === customColorCode}
+          onClick={() => {
+            setSelectedColor(customColorCode);
+          }}
+        >
+          확인
+        </Button.Plain>
+      </StyledButtonWrapper>
+    </StyledInputWrapper>
+  ) : (
     <StyledContainer>
       {colors.map((color) => (
         <StyledColorBox
@@ -60,4 +97,42 @@ const StyledColorBox = styled.div<{ $isSelected: boolean; $color: string }>`
 
     display: ${(props) => (props.$isSelected ? 'flex' : 'none')};
   }
+`;
+
+const StyledInput = styled.input<{ $isError: boolean }>`
+  width: 220px;
+  padding: 10px;
+  border: 1px solid ${GRAY[30]};
+  border-radius: 15px;
+
+  border-color: ${(props) => (props.$isError ? `${RED}` : null)};
+
+  &:focus-within {
+    border-color: ${VIOLET[1]};
+  }
+`;
+
+const StyledInputWrapper = styled.div`
+  height: 60px;
+
+  display: flex;
+  gap: 10px;
+`;
+
+const StyledErrorMsg = styled.div`
+  padding-left: 5px;
+  color: ${RED};
+  ${FONT_12};
+`;
+
+const StyledButtonWrapper = styled.div`
+  margin-top: 1px;
+  width: 50px;
+  height: 38px;
+`;
+
+const StyledErrorWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
 `;

--- a/components/common/DropDown/MemberDropDown.tsx
+++ b/components/common/DropDown/MemberDropDown.tsx
@@ -1,0 +1,45 @@
+import { MemberListType } from '@/lib/types/members';
+import Profile from '../Profile/Profile';
+import styled from 'styled-components';
+import { GRAY } from '@/styles/ColorStyles';
+import { customScroll } from '@/styles/CustomScroll';
+
+interface Props {
+  memberList: MemberListType[];
+}
+
+function MemberDropDown({ memberList }: Props) {
+  return (
+    <StyledContainer>
+      <StyledScroll>
+        {memberList.map(({ id, nickname, profileImageUrl }) => (
+          <Profile type="member" id={id} name={nickname} profileImg={profileImageUrl} />
+        ))}
+      </StyledScroll>
+    </StyledContainer>
+  );
+}
+
+export default MemberDropDown;
+
+const StyledContainer = styled.div`
+  width: 200px;
+  padding: 10px;
+  padding-right: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  background-color: white;
+  border: 2px solid ${GRAY[30]};
+  border-radius: 12px;
+  box-shadow: 0px 0px 10px ${GRAY[30]};
+`;
+
+const StyledScroll = styled.div`
+  height: 200px;
+  overflow-y: scroll;
+
+  ${customScroll};
+`;

--- a/components/common/Header/SecondHeader/SecondHeader.tsx
+++ b/components/common/Header/SecondHeader/SecondHeader.tsx
@@ -31,8 +31,8 @@ function Header({ page, children, crown, membersData }: Props) {
     <StyledBody>
       <StyledContainer $page={page}>
         <StyledTitleSection $page={page}>
-          <StyledTitle>{children}</StyledTitle>
           {crown && <StyledCrownIcon />}
+          <StyledTitle>{children}</StyledTitle>
         </StyledTitleSection>
         <StyledRight>
           {page !== 'myboard' && (
@@ -113,8 +113,8 @@ const StyledBody = styled.div`
 
 const StyledContainer = styled.div<{ $page: string }>`
   width: 100%;
-  padding-left: 30px;
-  padding-right: 60px;
+  padding-left: 20px;
+  padding-right: 40px;
 
   display: flex;
   align-items: center;
@@ -134,11 +134,7 @@ const StyledContainer = styled.div<{ $page: string }>`
 
 const StyledRight = styled.div`
   display: flex;
-  gap: 32px;
-
-  @media (max-width: ${DEVICE_SIZE.tablet}) {
-    gap: 24px;
-  }
+  gap: 24px;
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     gap: 12px;
@@ -148,7 +144,7 @@ const StyledRight = styled.div`
 const StyledTitleSection = styled.div<{ $page: string }>`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     display: ${(props) => (props.$page === 'others' ? `none` : null)};
@@ -208,7 +204,7 @@ const StyledInviteWrapper = styled.div`
 
 const StyledTitle = styled.div`
   min-width: 5vw;
-  max-width: 20vw;
+  max-width: 18vw;
 
   color: ${BLACK[2]};
   ${FONT_20_B};

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -9,8 +9,7 @@ import { createDashboard } from '@/api/dashboards/createDashboard';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/context/stores';
 import { ERROR_MSG } from '@/lib/constants/inputErrorMsg';
-import { FONT_16 } from '@/styles/FontStyles';
-import { BLACK, GRAY, VIOLET } from '@/styles/ColorStyles';
+import ColorChoice from '../Chip/ColorChoice';
 
 interface Props {
   type: modalType;
@@ -18,7 +17,6 @@ interface Props {
 
 function DashboardModal({ type }: Props) {
   const { push } = useRouter();
-  const [colorTheme, setColorTheme] = useState('pastel');
   const [color, setColor] = useState('');
   const { hideModal } = useStore((state) => ({ hideModal: state.hideModal }));
   const {
@@ -53,23 +51,7 @@ function DashboardModal({ type }: Props) {
             error={errors.newDashboard}
             isHookForm
           />
-          <StyledColorWrapper>
-            <StyledText>색상 선택</StyledText>
-            <StyledThemeWrapper>
-              <StyledTheme $isSelected={'pastel' === colorTheme} onClick={() => setColorTheme('pastel')}>
-                PASTEL
-              </StyledTheme>
-              <StyledTheme $isSelected={'vivid' === colorTheme} onClick={() => setColorTheme('vivid')}>
-                VIVID
-              </StyledTheme>
-              <StyledTheme $isSelected={'custom' === colorTheme} onClick={() => setColorTheme('custom')}>
-                CUSTOM
-              </StyledTheme>
-            </StyledThemeWrapper>
-            <StyledChipWrapper>
-              <DashBoardColor theme={colorTheme} selectedColor={color} setSelectedColor={setColor} isInModal={true} />
-            </StyledChipWrapper>
-          </StyledColorWrapper>
+          <ColorChoice color={color} setColor={setColor} />
         </form>
       </ModalFrame>
     </>
@@ -77,45 +59,3 @@ function DashboardModal({ type }: Props) {
 }
 
 export default DashboardModal;
-
-const StyledColorWrapper = styled.div`
-  margin-top: 20px;
-
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-`;
-
-const StyledText = styled.div`
-  ${FONT_16};
-  color: ${BLACK[2]};
-`;
-
-const StyledThemeWrapper = styled.div`
-  display: flex;
-  gap: 10px;
-`;
-
-const StyledTheme = styled.div<{ $isSelected: boolean }>`
-  width: 75px;
-  padding: 5px 8px;
-
-  display: flex;
-  justify-content: center;
-
-  border: 1px solid ${GRAY[30]};
-  border-radius: 10px;
-
-  color: ${(props) => (props.$isSelected ? `${VIOLET[1]}` : null)};
-  background-color: ${(props) => (props.$isSelected ? `${VIOLET[8]}` : null)};
-
-  &:hover {
-    cursor: pointer;
-    background-color: ${VIOLET[8]};
-  }
-`;
-
-const StyledChipWrapper = styled.div`
-  margin-top: 10px;
-  justify-content: flex-start;
-`;

--- a/components/common/Modal/DashboardModal.tsx
+++ b/components/common/Modal/DashboardModal.tsx
@@ -9,6 +9,8 @@ import { createDashboard } from '@/api/dashboards/createDashboard';
 import { useRouter } from 'next/navigation';
 import { useStore } from '@/context/stores';
 import { ERROR_MSG } from '@/lib/constants/inputErrorMsg';
+import { FONT_16 } from '@/styles/FontStyles';
+import { BLACK, GRAY, VIOLET } from '@/styles/ColorStyles';
 
 interface Props {
   type: modalType;
@@ -16,6 +18,7 @@ interface Props {
 
 function DashboardModal({ type }: Props) {
   const { push } = useRouter();
+  const [colorTheme, setColorTheme] = useState('pastel');
   const [color, setColor] = useState('');
   const { hideModal } = useStore((state) => ({ hideModal: state.hideModal }));
   const {
@@ -51,7 +54,21 @@ function DashboardModal({ type }: Props) {
             isHookForm
           />
           <StyledColorWrapper>
-            <DashBoardColor selectedColor={color} setSelectedColor={setColor} isInModal={true} />
+            <StyledText>색상 선택</StyledText>
+            <StyledThemeWrapper>
+              <StyledTheme $isSelected={'pastel' === colorTheme} onClick={() => setColorTheme('pastel')}>
+                PASTEL
+              </StyledTheme>
+              <StyledTheme $isSelected={'vivid' === colorTheme} onClick={() => setColorTheme('vivid')}>
+                VIVID
+              </StyledTheme>
+              <StyledTheme $isSelected={'custom' === colorTheme} onClick={() => setColorTheme('custom')}>
+                CUSTOM
+              </StyledTheme>
+            </StyledThemeWrapper>
+            <StyledChipWrapper>
+              <DashBoardColor theme={colorTheme} selectedColor={color} setSelectedColor={setColor} isInModal={true} />
+            </StyledChipWrapper>
           </StyledColorWrapper>
         </form>
       </ModalFrame>
@@ -62,7 +79,43 @@ function DashboardModal({ type }: Props) {
 export default DashboardModal;
 
 const StyledColorWrapper = styled.div`
-  width: 100%;
+  margin-top: 20px;
+
   display: flex;
+  flex-direction: column;
+  gap: 5px;
+`;
+
+const StyledText = styled.div`
+  ${FONT_16};
+  color: ${BLACK[2]};
+`;
+
+const StyledThemeWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const StyledTheme = styled.div<{ $isSelected: boolean }>`
+  width: 75px;
+  padding: 5px 8px;
+
+  display: flex;
+  justify-content: center;
+
+  border: 1px solid ${GRAY[30]};
+  border-radius: 10px;
+
+  color: ${(props) => (props.$isSelected ? `${VIOLET[1]}` : null)};
+  background-color: ${(props) => (props.$isSelected ? `${VIOLET[8]}` : null)};
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${VIOLET[8]};
+  }
+`;
+
+const StyledChipWrapper = styled.div`
   margin-top: 10px;
+  justify-content: flex-start;
 `;

--- a/components/common/Modal/InviteModal.tsx
+++ b/components/common/Modal/InviteModal.tsx
@@ -33,7 +33,7 @@ function InviteModal({ dashboardId }: Props) {
       showModal('inviteAlert');
     } else {
       clearModal();
-      window.location.reload();
+      setTimeout(() => window.location.reload(), 1000);
     }
   };
 

--- a/components/common/Profile/Profile.tsx
+++ b/components/common/Profile/Profile.tsx
@@ -1,17 +1,18 @@
 import { useState } from 'react';
 import styled, { css } from 'styled-components';
 import ProfileImg from './ProfileImg';
-import { FONT_16 } from '@/styles/FontStyles';
+import { FONT_14, FONT_16 } from '@/styles/FontStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import UpIcon from '@/public/icon/small-up.svg';
 import DownIcon from '@/public/icon/small-down.svg';
 import HeaderDropDown from '../DropDown/HeaderDropDown';
+import { BLACK, GRAY } from '@/styles/ColorStyles';
 
 interface Props {
-  type: 'header' | 'card';
+  type: 'header' | 'card' | 'member';
   id: number;
   name: string;
-  profileImg: string;
+  profileImg: string | null;
 }
 
 function Profile({ type, id, name, profileImg }: Props) {
@@ -25,7 +26,7 @@ function Profile({ type, id, name, profileImg }: Props) {
     <>
       {isOpen && <StyledMask onClick={() => setIsOpen(false)} />}
       <StyledContainer $type={type}>
-        <ProfileImg url={profileImg} size={38} name={name} id={id} />
+        <ProfileImg url={profileImg} size={38} name={name} id={id} type={type} />
         <StyledNameWrapper $type={type} onClick={handleDropdownClick}>
           <StyledName $type={type}>{name}</StyledName>
           {type === 'header' && (isOpen ? <StyledUpIcon /> : <StyledDownIcon />)}
@@ -48,7 +49,7 @@ const invisibleMobile = css`
   }
 `;
 
-const StyledContainer = styled.div<{ $type: 'header' | 'card' }>`
+const StyledContainer = styled.div<{ $type: string }>`
   display: flex;
   align-items: center;
   justify-content: ${(props) => (props.$type === 'header' ? 'space-between' : 'flex-start')};
@@ -61,7 +62,9 @@ const StyledContainer = styled.div<{ $type: 'header' | 'card' }>`
 
 const StyledName = styled.div<{ $type: string }>`
   ${FONT_16};
+  color: ${BLACK[2]};
 
+  ${(props) => (props.$type === 'member' ? `${FONT_14}` : null)};
   ${(props) => (props.$type === 'header' ? invisibleMobile : null)};
 `;
 

--- a/components/common/Profile/ProfileImg.tsx
+++ b/components/common/Profile/ProfileImg.tsx
@@ -4,7 +4,7 @@ import { FONT_12, FONT_16 } from '@/styles/FontStyles';
 import Image from 'next/image';
 import styled from 'styled-components';
 
-const COLORS = [BLUE, ORANGE, PURPLE, GREEN, PINK[1]];
+const COLORS = [BLUE[1], ORANGE[1], PURPLE[1], GREEN[1], PINK[1]];
 
 interface Props {
   url: string | null;

--- a/components/common/Profile/ProfileImg.tsx
+++ b/components/common/Profile/ProfileImg.tsx
@@ -7,13 +7,14 @@ import styled from 'styled-components';
 const COLORS = [BLUE, ORANGE, PURPLE, GREEN, PINK[1]];
 
 interface Props {
-  url: string;
+  url: string | null;
   size: number;
   name: string;
   id: number;
+  type?: string;
 }
 
-function ProfileImg({ url, size, name, id }: Props) {
+function ProfileImg({ url, size, name, id, type }: Props) {
   const colorNum = id % 5;
 
   return (
@@ -25,7 +26,7 @@ function ProfileImg({ url, size, name, id }: Props) {
           {name.slice(0, 1)}
         </StyledDefaultProfile>
       )}
-      <StyledNickName>{name}</StyledNickName>
+      {type === 'header' && <StyledNickName>{name}</StyledNickName>}
     </StyledWrapper>
   );
 }

--- a/components/common/Profile/ProfileImgList.tsx
+++ b/components/common/Profile/ProfileImgList.tsx
@@ -1,13 +1,16 @@
 import styled from 'styled-components';
-import { FONT_14, FONT_14_B, FONT_16, FONT_16_B } from '@/styles/FontStyles';
+import { FONT_14_B, FONT_16_B } from '@/styles/FontStyles';
 import { Z_INDEX } from '@/styles/ZIndexStyles';
 import { PINK, WHITE } from '@/styles/ColorStyles';
 import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import ProfileImg from './ProfileImg';
+import { MemberListType } from '@/lib/types/members';
+import { useState } from 'react';
+import MemberDropDown from '../DropDown/MemberDropDown';
 
 interface Props {
   memberCount: number;
-  data: any[];
+  data: MemberListType[];
 }
 
 /**
@@ -15,37 +18,84 @@ interface Props {
  * @param data members 배열
  */
 function ProfileImgList({ memberCount, data }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
   const PcRest = memberCount - 4;
   const TabletRest = memberCount - 2;
 
   if (!memberCount) return;
 
+  const handleRestClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+
   return (
     <StyledContainer>
       {data[0] && (
         <StyledProfileWrapper $order={Z_INDEX.profileImgList_Img[0]}>
-          <ProfileImg url={data[0].profileImageUrl} size={38} name={data[0].nickname} id={data[0].userId} />
+          <ProfileImg
+            type="header"
+            url={data[0].profileImageUrl}
+            size={38}
+            name={data[0].nickname}
+            id={data[0].userId}
+          />
         </StyledProfileWrapper>
       )}
       {data[1] && (
         <StyledProfileWrapper $order={Z_INDEX.profileImgList_Img[1]}>
-          <ProfileImg url={data[1].profileImageUrl} size={38} name={data[1].nickname} id={data[1].userId} />
+          <ProfileImg
+            type="header"
+            url={data[1].profileImageUrl}
+            size={38}
+            name={data[1].nickname}
+            id={data[1].userId}
+          />
         </StyledProfileWrapper>
       )}
       <StyledWrapper>
         {data[2] && (
           <StyledProfileWrapper $order={Z_INDEX.profileImgList_Img[2]}>
-            <ProfileImg url={data[2].profileImageUrl} size={38} name={data[2].nickname} id={data[2].userId} />
+            <ProfileImg
+              type="header"
+              url={data[2].profileImageUrl}
+              size={38}
+              name={data[2].nickname}
+              id={data[2].userId}
+            />
           </StyledProfileWrapper>
         )}
         {data[3] && (
           <StyledProfileWrapper $order={Z_INDEX.profileImgList_Img[3]}>
-            <ProfileImg url={data[3].profileImageUrl} size={38} name={data[3].nickname} id={data[3].userId} />
+            <ProfileImg
+              type="header"
+              url={data[3].profileImageUrl}
+              size={38}
+              name={data[3].nickname}
+              id={data[3].userId}
+            />
           </StyledProfileWrapper>
         )}
       </StyledWrapper>
-      {memberCount > 4 && <StyledPCRest $order={5}>+{PcRest <= 999 ? PcRest : '999'}</StyledPCRest>}
-      {memberCount > 2 && <StyledTabletRest $order={3}>+{TabletRest <= 999 ? TabletRest : '999'}</StyledTabletRest>}
+      {memberCount > 4 && (
+        <StyledPCRest onClick={handleRestClick} $order={5}>
+          +{PcRest <= 999 ? PcRest : '999'}
+          {isOpen && (
+            <StyledDropDownWrapper>
+              <MemberDropDown memberList={data} />
+            </StyledDropDownWrapper>
+          )}
+        </StyledPCRest>
+      )}
+      {memberCount > 2 && (
+        <StyledTabletRest onClick={handleRestClick} $order={3}>
+          +{TabletRest <= 999 ? TabletRest : '999'}
+          {isOpen && (
+            <StyledDropDownWrapper>
+              <MemberDropDown memberList={data} />
+            </StyledDropDownWrapper>
+          )}
+        </StyledTabletRest>
+      )}
     </StyledContainer>
   );
 }
@@ -94,6 +144,11 @@ const StyledRest = styled.div<{ $order: number }>`
 `;
 
 const StyledPCRest = styled(StyledRest)`
+  position: relative;
+
+  &:hover {
+    cursor: pointer;
+  }
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     display: none;
   }
@@ -101,7 +156,11 @@ const StyledPCRest = styled(StyledRest)`
 
 const StyledTabletRest = styled(StyledRest)`
   display: none;
+  position: relative;
 
+  &:hover {
+    cursor: pointer;
+  }
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     display: flex;
   }
@@ -112,4 +171,10 @@ const StyledWrapper = styled(StyledContainer)`
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     display: none;
   }
+`;
+
+const StyledDropDownWrapper = styled.div`
+  position: absolute;
+  top: 38px;
+  right: -10px;
 `;

--- a/components/common/Table/EditMyDash.tsx
+++ b/components/common/Table/EditMyDash.tsx
@@ -8,6 +8,10 @@ import { DEVICE_SIZE } from '@/styles/DeviceSize';
 import { GetDashboardListDetailResponseType } from '@/lib/types/dashboards';
 import { editDashboard } from '@/api/dashboards/editDashboard';
 import { tree } from 'next/dist/build/templates/app-page';
+import { useStore } from '@/context/stores';
+import ColorChoice from '../Chip/ColorChoice';
+import UpIcon from '@/public/icon/small-up.svg';
+import DownIcon from '@/public/icon/small-down.svg';
 
 interface Props {
   dashboardData: GetDashboardListDetailResponseType;
@@ -21,6 +25,7 @@ function EditMyDash({ dashboardData }: Props) {
   const [isNotActive, setIsNotActive] = useState(true);
   const [dashData, setDashData] = useState(dashboardData);
   const [editName, setEditName] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
 
   const OnNameChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
@@ -40,17 +45,29 @@ function EditMyDash({ dashboardData }: Props) {
     setEditName('');
   };
 
+  const handleEditColorClick = () => {
+    setIsOpen((prev) => !prev);
+  };
+
   useEffect(() => {
     setSelectedColor(colors[colorIndex]);
     setDashData(dashboardData);
   }, [colorIndex]);
 
+  useEffect(() => {
+    setSelectedColor(initialColor);
+  }, []);
+
+  console.log(selectedColor, initialColor);
+
   return (
     <Wrapper>
       <Container>
         <EditDashChip>
-          <BoardTitle>{dashData.title}</BoardTitle>
-          <DashBoardColor selectedColor={selectedColor} setSelectedColor={setSelectedColor} />
+          <ColorWrapper>
+            {selectedColor && <Chip $color={selectedColor} />}
+            <BoardTitle>{dashData.title}</BoardTitle>
+          </ColorWrapper>
         </EditDashChip>
         <EditDashName>
           <DashNameText>대시보드 이름</DashNameText>
@@ -63,6 +80,11 @@ function EditMyDash({ dashboardData }: Props) {
             />
           </EditNameInputWrap>
         </EditDashName>
+        <EditColorWrapper onClick={handleEditColorClick}>
+          <ColorEdit>색상 변경</ColorEdit>
+          {isOpen ? <StyledUpIcon /> : <StyledDownIcon />}{' '}
+        </EditColorWrapper>
+        {isOpen && <ColorChoice type="edit" color={selectedColor} setColor={setSelectedColor} />}
         <EditButton>
           <ButtonWrapper>
             <Button.Plain style="primary" roundSize="M" onClick={handleSubmit} isNotActive={isNotActive}>
@@ -79,19 +101,17 @@ export default EditMyDash;
 
 const Wrapper = styled.div`
   width: 620px;
-  height: 256px;
   border-radius: 8px;
   background-color: ${[WHITE]};
   padding: 32px 28px;
 
   @media (max-width: ${DEVICE_SIZE.tablet}) {
     width: 544px;
-    height: 256px;
   }
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     width: 284px;
-    height: 211px;
+
     padding: 27px 20px 21px;
   }
 `;
@@ -169,5 +189,45 @@ const ButtonText = styled.text`
 
   @media (max-width: ${DEVICE_SIZE.mobile}) {
     height: 28px;
+  }
+`;
+
+const Chip = styled.div<{ $color: string }>`
+  width: 15px;
+  height: 15px;
+
+  border-radius: 100%;
+  background-color: ${(props) => props.$color};
+`;
+
+const ColorWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const ColorEdit = styled.div`
+  ${FONT_18};
+`;
+
+const StyledDownIcon = styled(DownIcon)`
+  width: 18px;
+  height: 18px;
+`;
+
+const StyledUpIcon = styled(UpIcon)`
+  width: 18px;
+  height: 18px;
+`;
+
+const EditColorWrapper = styled.div`
+  padding-top: 10px;
+  display: flex;
+  gap: 5px;
+
+  align-items: center;
+
+  &:hover {
+    cursor: pointer;
   }
 `;

--- a/lib/constants/inputErrorMsg.ts
+++ b/lib/constants/inputErrorMsg.ts
@@ -1,40 +1,40 @@
 // Email 관련
-export const voidEmail = '이메일을 입력해주세요.';
+export const voidEmail = '이메일을 입력해 주세요.';
 export const incorrectEmail = '올바른 이메일 주소가 아닙니다.';
 
 // Password 관련
-export const voidPassword = '비밀번호를 입력해주세요.';
-export const incorrectPassword = '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.';
+export const voidPassword = '비밀번호를 입력해 주세요.';
+export const incorrectPassword = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
 export const doubleCheckPassword = '비밀번호가 일치하지 않아요.';
 
 // 제목
-export const voidTitle = '제목을 입력해주세요.';
+export const voidTitle = '제목을 입력해 주세요.';
 
 // 마감일
-export const voidDueDate = '마감일을 입력해주세요.';
+export const voidDueDate = '마감일을 입력해 주세요.';
 
 // 칼럼 이름
 export const overlapName = '중복된 칼럼 이름입니다.';
-export const voidName = '이름을 입력해주세요.';
+export const voidName = '이름을 입력해 주세요.';
 
 // url
-export const voidUrl = 'Url을 입력해주세요.';
+export const voidUrl = 'Url을 입력해 주세요.';
 
 // etc
 export const voidEtc = '입력된 값이 없습니다. 입력해주세요.';
 
 export const ERROR_MSG = {
-  emptyEmail: '이메일을 입력해주세요.',
-  emptyPassword: '비밀번호를 입력해주세요.',
+  emptyEmail: '이메일을 입력해 주세요.',
+  emptyPassword: '비밀번호를 입력해 주세요.',
   invalidEmail: '올바른 이메일 주소가 아닙니다.',
-  invalidPassword: '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.',
-  wrongEmail: '이메일을 확인해주세요.',
-  wrongPassword: '비밀번호를 확인해주세요.',
+  invalidPassword: '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.',
+  wrongEmail: '이메일을 확인해 주세요.',
+  wrongPassword: '비밀번호를 확인해 주세요.',
   notEqualPassword: '비밀번호가 일치하지 않아요.',
   duplicatedEmail: '이미 사용중인 이메일입니다.',
-  emptyNickname: '닉네임을 입력해주세요.',
-  invalidNickname: '2자 이상 10자 이하, 영어 또는 숫자 또는 한글로 입력해주세요.',
+  emptyNickname: '닉네임을 입력해 주세요.',
+  invalidNickname: '2자 이상 10자 이하, 영어 또는 숫자 또는 한글로 입력해 주세요.',
   signUpSuccessAlert: '회원가입이 성공적으로 완료되었습니다.',
-  signUpFailedAlert: '회원가입에 실패했습니다. 다시 시도해주세요.',
-  emptyDashboardName: '대시보드 이름은 1글자 이상 입력해주세요.',
+  signUpFailedAlert: '회원가입에 실패했습니다. 다시 시도해 주세요.',
+  emptyDashboardName: '대시보드 이름은 1글자 이상 입력해 주세요.',
 };

--- a/lib/constants/inputErrorRules.ts
+++ b/lib/constants/inputErrorRules.ts
@@ -1,5 +1,13 @@
 import { ERROR_MSG } from '@/lib/constants/inputErrorMsg';
 
+export const colorCodeRules = {
+  required: '값을 입력해주세요.',
+  pattern: {
+    value: /^#[a-zA-Z0-9]{6}$/,
+    message: '형식이 맞지 않아요.',
+  },
+};
+
 export const emailRules = {
   required: ERROR_MSG.emptyEmail,
   pattern: {

--- a/lib/types/zustand.ts
+++ b/lib/types/zustand.ts
@@ -23,7 +23,8 @@ export type modalType =
   | 'invite'
   | 'inviteAlert'
   | 'imgError'
-  | 'loading';
+  | 'loading'
+  | 'editColor';
 
 export interface ModalState {
   modals: modalType[];

--- a/pages/board/[id]/edit.tsx
+++ b/pages/board/[id]/edit.tsx
@@ -26,9 +26,9 @@ function Edit() {
   const dashboardId = Number(id);
 
   const hadnlerDashBoardDelete = async () => {
-    if (confirm('대쉬보드를 삭제하시겠습니까?')) {
+    if (confirm('대시보드를 삭제하시겠습니까?')) {
       await deleteDashboard(dashboardId);
-      alert('대쉬보드를 삭제했습니다.');
+      alert('대시보드를 삭제했습니다.');
       router.push('/myboard');
     }
   };

--- a/styles/ColorStyles.ts
+++ b/styles/ColorStyles.ts
@@ -21,14 +21,16 @@ export const VIOLET = {
 };
 
 export const PINK = {
-  1: '#F9C7CD',
+  0: '#F9C7CD', //pastel
+  1: '#E876EA', //vivid
   2: '#F4D7DA',
   3: '#D25B68',
 };
 
+export const GREEN = { 0: '#CAE3DE', 1: '#7AC555' };
+export const PURPLE = { 0: '#D3C1EB', 1: '#760DDE' };
+export const ORANGE = { 0: '#FFDB99', 1: '#FFA500' };
+export const BLUE = { 0: '#BDDAEF', 1: '#76A5EA' };
+
 export const WHITE = '#FFFFFF';
 export const RED = '#D6173A';
-export const GREEN = '#CAE3DE';
-export const PURPLE = '#D3C1EB';
-export const ORANGE = '#FFDB99';
-export const BLUE = '#BDDAEF';


### PR DESCRIPTION
## 수정 내용

- 헤더에 숫자 누르면 멤버 드롭다운 뜨게 했어요! (근데 데이터 받아오는 형식이라 무한스크롤 불가,,,,,ㅠ)
- 컬러칩 방식 변경했어요ㅎㅎ 커스텀 색깔 가능 >< (edit 페이지에도 반영함!)

## 스크린샷
<img width="396" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/fe58b590-0611-49ea-bf61-eb66ec0f4df0">
<img width="219" alt="image" src="https://github.com/like-tenten/tenten/assets/103186362/c38e1bf5-8c74-4dd4-a270-444aa29ec8f2">


## 기타
